### PR TITLE
Fixing Schedule Download Issue

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -100,14 +100,18 @@ const Header = ({
     const captureElement = captureRef.current;
     if (captureElement == null) return;
 
+    const computed = window
+      .getComputedStyle(captureElement)
+      .getPropertyValue('left');
+
     domtoimage
-      .toPng(captureElement, {
+      .toBlob(captureElement, {
         width: captureElement.offsetWidth * PNG_SCALE_FACTOR,
         height: captureElement.offsetHeight * PNG_SCALE_FACTOR,
         style: {
-          left: 0,
           transform: `scale(${PNG_SCALE_FACTOR})`,
-          'transform-origin': 'top left'
+          'transform-origin': `${computed} 0px`,
+          'background-color': '#333333'
         }
       })
       .then((blob) => saveAs(blob, 'schedule.png'));

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -111,11 +111,11 @@ const Header = ({
         style: {
           transform: `scale(${PNG_SCALE_FACTOR})`,
           'transform-origin': `${computed} 0px`,
-          'background-color': '#333333'
+          'background-color': theme === 'light' ? '#FFFFFF' : '#333333'
         }
       })
       .then((blob) => saveAs(blob, 'schedule.png'));
-  }, [captureRef]);
+  }, [captureRef, theme]);
 
   // Re-render when the page is re-sized to become mobile/desktop
   // (desktop is >= 1024 px wide)


### PR DESCRIPTION
This pull request should fix Issue #2.

Problem Identified:
When transforming the origin position of the calendar, the left position used was a relative position.

Solution:
Use computed left position of the element, transform the calendar left by that computed value. Essentially moving the calendar, to the left edge of the screen, eliminating the position of `<CourseContainer />` and `<CombinationContainer />`.

Other small tweaks:
Added background color to the PNG file.
Changed to using `domtoimg.toBlob()` instead of `domtoimg.toPNG()` since we are using the blob to save as PNG files.
