### PR TITLE
Migrate finished day selection from GTBitsOfGood/gt-scheduler#26

### DIFF
--- a/src/components/ActionRow/index.tsx
+++ b/src/components/ActionRow/index.tsx
@@ -1,18 +1,38 @@
 import React from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { classes } from '../../utils';
+import Button, { ButtonProps } from '../Button';
+
 import './stylesheet.scss';
-import { Button } from '..';
+
+type FontAwesomeProps = React.ComponentProps<typeof FontAwesomeIcon>;
+export type Action = {
+  icon: FontAwesomeProps['icon'];
+  styling?: React.CSSProperties;
+  dataTip?: string;
+  dataFor?: string;
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
+} & Omit<ButtonProps, 'children'>;
+
+type BaseActionRowProps = {
+  label: string;
+  actions: Action[];
+  className?: string;
+  children?: React.ReactNode;
+};
+export type ActionRowProps = BaseActionRowProps &
+  Omit<React.HTMLAttributes<HTMLDivElement>, keyof BaseActionRowProps>;
 
 export default function ActionRow({
   className,
   label,
   children,
   actions,
-  ...props
-}) {
+  ...restProps
+}: ActionRowProps) {
   return (
-    <div className={classes('ActionRow', className)} {...props}>
+    <div className={classes('ActionRow', className)} {...restProps}>
       <div className="action-row-header">
         <div className="label">{label}</div>
         <div className={classes('actions', 'default')}>
@@ -22,22 +42,20 @@ export default function ActionRow({
               (
                 {
                   icon,
-                  title,
                   styling,
                   dataTip,
                   dataFor,
                   onMouseEnter,
                   onMouseLeave,
-                  ...restProps
+                  ...rest
                 },
                 i
               ) => (
-                <Button className="action" {...restProps} key={i}>
+                <Button className="action" {...rest} key={i}>
                   <FontAwesomeIcon
                     fixedWidth
                     style={styling}
                     icon={icon}
-                    title={title}
                     data-tip={dataTip}
                     data-for={dataFor}
                     onMouseEnter={onMouseEnter}

--- a/src/components/DaySelection/index.tsx
+++ b/src/components/DaySelection/index.tsx
@@ -63,7 +63,9 @@ export default function DaySelection({
           {activeDay === date && (
             <div className="dropdown-content">
               {courseDateMap[date as Day].length === 0 ? (
-                <div className="course-content">No classes this day!</div>
+                <div className="course-content" style={{ padding: 8 }}>
+                  No classes this day!
+                </div>
               ) : (
                 courseDateMap[date as Day].map((course: any) => (
                   <div className="course-content">

--- a/src/components/DaySelection/index.tsx
+++ b/src/components/DaySelection/index.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { faAngleDown, faAngleUp } from '@fortawesome/free-solid-svg-icons';
+import { ActionRow } from '..';
+import { classes, getContentClassName } from '../../utils';
+
+import './stylesheet.scss';
+
+type Day = 'M' | 'T' | 'W' | 'R' | 'F';
+export type DaySelectionProps = {
+  courseDateMap: Record<Day, object[]>;
+  activeDay: Day | '';
+  setActiveDay: (next: Day | '') => void;
+};
+
+export default function DaySelection({
+  courseDateMap,
+  activeDay,
+  setActiveDay
+}: DaySelectionProps) {
+  const colorPalette = ['#FCB9AA', '#FFDBCC', '#ECEAE4', '#A2E1DB', '#55CBCD'];
+  const daysOfTheWeek = [
+    'Monday',
+    'Tuesday',
+    'Wednesday',
+    'Thursday',
+    'Friday'
+  ];
+
+  const formatTime = (time: number): string => {
+    if (Math.floor(time / 60) > 12) {
+      return `${Math.floor(time / 60) % 12}:${
+        time % 60 === 0 ? '00' : time % 60
+      }pm`;
+    }
+    return `${Math.floor(time / 60)}:${time % 60 === 0 ? '00' : time % 60}am`;
+  };
+
+  return (
+    <div className="date-container">
+      {Object.keys(courseDateMap).map((date, i) => (
+        <div
+          key={date}
+          className={classes(
+            'date',
+            getContentClassName(colorPalette[i]),
+            'default'
+          )}
+          style={{ backgroundColor: colorPalette[i] }}
+        >
+          <ActionRow
+            label={daysOfTheWeek[i]}
+            className="day-select"
+            actions={[
+              {
+                icon: date === activeDay ? faAngleUp : faAngleDown,
+                onClick: () =>
+                  date !== activeDay
+                    ? setActiveDay(date as Day)
+                    : setActiveDay('')
+              }
+            ]}
+          />
+          {activeDay === date && (
+            <div className="dropdown-content">
+              {courseDateMap[date as Day].length === 0 ? (
+                <div className="course-content">No classes this day!</div>
+              ) : (
+                courseDateMap[date as Day].map((course: any) => (
+                  <div className="course-content">
+                    <div className="course-id">{course.id}</div>
+                    <span className="course-row">{course.title}</span>
+                    <span className="course-row">
+                      {course.daysOfWeek} {formatTime(course.times.start)} -{' '}
+                      {formatTime(course.times.end)}
+                    </span>
+                  </div>
+                ))
+              )}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/DaySelection/stylesheet.scss
+++ b/src/components/DaySelection/stylesheet.scss
@@ -3,6 +3,17 @@
 .date-container {
   width: 320px;
 
+  @media (max-width: 900px) {
+    width: 220px;
+  }
+
+  @media (max-width: 500px) {
+    width: 100%;
+    height: 180px;
+    overflow-y: auto;
+    border-bottom: 4px solid var(--theme-bg);
+  }
+
   .date {
     @include card;
 

--- a/src/components/DaySelection/stylesheet.scss
+++ b/src/components/DaySelection/stylesheet.scss
@@ -1,0 +1,30 @@
+@import '../../variables';
+
+.date-container {
+  width: 320px;
+
+  .date {
+    @include card;
+
+    .day-select {
+      box-shadow: 1px 1px 1px gray;
+    }
+
+    .dropdown-content {
+      .course-content {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+        padding: 4px;
+        .course-id {
+          font-weight: bold;
+        }
+        .course-row {
+          padding: 4px;
+          display: flex;
+        }
+      }
+    }
+  }
+}

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -4,9 +4,11 @@ import { periodToString } from '../../utils';
 import { TermContext } from '../../contexts';
 import DaySelection from '../DaySelection';
 
+import './stylesheet.scss';
+
 const Map = () => {
   const [{ oscar, pinnedCrns }] = useContext(TermContext);
-  const [activeDay, setActiveDay] = useState('');
+  const [activeDay, setActiveDay] = useState('M');
   const locations = [];
   const courseDateMap = {
     M: [],
@@ -48,7 +50,7 @@ const Map = () => {
   }
 
   return (
-    <div className="map-content" style={{ display: 'flex', height: '100vh' }}>
+    <div className="map-content">
       <DaySelection
         courseDateMap={courseDateMap}
         activeDay={activeDay}

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -1,15 +1,34 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import MapView from '../MapView';
 import { periodToString } from '../../utils';
 import { TermContext } from '../../contexts';
+import DaySelection from '../DaySelection';
 
 const Map = () => {
   const [{ oscar, pinnedCrns }] = useContext(TermContext);
+  const [activeDay, setActiveDay] = useState('');
   const locations = [];
+  const courseDateMap = {
+    M: [],
+    T: [],
+    W: [],
+    R: [],
+    F: []
+  };
 
+  // Construct the courseDateMap and locations data structures
   pinnedCrns.forEach((crn) => {
     const info = oscar.crnMap[crn.toString()];
     const meetings = info.meetings[0];
+
+    meetings.days.forEach((day) => {
+      courseDateMap[day].push({
+        id: info.course.id,
+        title: info.course.title,
+        times: meetings.period,
+        daysOfWeek: meetings.days
+      });
+    });
 
     locations.push({
       section: info.id,
@@ -21,7 +40,23 @@ const Map = () => {
     });
   });
 
-  return <MapView locations={locations} />;
+  let activeLocations = [];
+  if (activeDay !== '') {
+    activeLocations = locations.filter((loc) =>
+      courseDateMap[activeDay].some((course) => course.id === loc.id)
+    );
+  }
+
+  return (
+    <div className="map-content" style={{ display: 'flex', height: '100vh' }}>
+      <DaySelection
+        courseDateMap={courseDateMap}
+        activeDay={activeDay}
+        setActiveDay={setActiveDay}
+      />
+      <MapView locations={activeLocations} />
+    </div>
+  );
 };
 
 export default Map;

--- a/src/components/Map/stylesheet.scss
+++ b/src/components/Map/stylesheet.scss
@@ -1,0 +1,8 @@
+.map-content {
+  display: flex;
+  height: 100vh;
+
+  @media (max-width: 500px) {
+    flex-direction: column;
+  }
+}

--- a/src/components/MapView/index.js
+++ b/src/components/MapView/index.js
@@ -12,7 +12,11 @@ const MapView = ({ locations }) => {
     width: '100%',
     zoom: 15
   });
+
   const unknown = [];
+  locations.forEach((location) => {
+    if (!location.coords) unknown.push(location);
+  });
 
   return (
     <div className="mapbox">
@@ -24,10 +28,9 @@ const MapView = ({ locations }) => {
         mapboxApiAccessToken={process.env.REACT_APP_MAPBOX_TOKEN}
         onViewportChange={(display) => setViewport(display)}
       >
-        {locations.map((location, i) => {
-          if (!location.coords) unknown.push(location);
-          return !location.coords ? (
-            <></>
+        {locations.map((location, i) =>
+          !location.coords ? (
+            <React.Fragment key={i} />
           ) : (
             <Marker
               key={i}
@@ -39,8 +42,8 @@ const MapView = ({ locations }) => {
                 {location.id} {location.section}
               </p>
             </Marker>
-          );
-        })}
+          )
+        )}
         {unknown.length > 0 && (
           <div className="unknown-container">
             <b>Undetermined</b>

--- a/src/components/MapView/stylesheet.scss
+++ b/src/components/MapView/stylesheet.scss
@@ -49,6 +49,11 @@
     background: white;
     color: #333333;
 
+    @media (max-width: 900px) {
+      margin-top: 8px;
+      margin-left: 8px;
+    }
+
     .class:first-of-type {
       margin-top: 8px;
     }

--- a/src/components/MapView/stylesheet.scss
+++ b/src/components/MapView/stylesheet.scss
@@ -2,7 +2,6 @@
   // subtract header height
   height: calc(100% - 64px);
   width: 100%;
-  z-index: -3;
 
   .pin-text {
     // right: svg width
@@ -11,7 +10,6 @@
     font-weight: bold;
     cursor: pointer;
     padding: 8px;
-    z-index: -2;
     margin: 0;
 
     box-shadow: 0px 0px 3px #00000080;
@@ -25,10 +23,7 @@
     align-items: center;
 
     svg {
-      z-index: -1;
-      filter: drop-shadow(
-        0px 0px 3px #00000080
-      );
+      filter: drop-shadow(0px 0px 3px #00000080);
     }
   }
 
@@ -37,7 +32,7 @@
     transform: translate(-9px, -32px);
     cursor: pointer;
     font-size: 2rem;
-    color: #C54848;
+    color: #c54848;
   }
 
   .unknown-container {
@@ -51,10 +46,15 @@
 
     border-radius: 8px;
     box-shadow: 0px 0px 3px #00000080;
-    background: white; color: #333333;
+    background: white;
+    color: #333333;
 
-    .class:first-of-type { margin-top: 8px; }
-    .class:not(:first-of-type) { margin-top: 3px; }
+    .class:first-of-type {
+      margin-top: 8px;
+    }
+    .class:not(:first-of-type) {
+      margin-top: 3px;
+    }
   }
 
   .navigation {


### PR DESCRIPTION
Originally authored by @sauravghosal

> Finished day selection component that allows users to select a particular day of the week to show class locations for. Integrated with MapView component and updated with Mapbox migration. ~~Will need to be styled for mobile screens~~, but currently works for most laptop and tablet views. (Edit: styles have been added to make it responsive)

![day selection](https://user-images.githubusercontent.com/33039426/98484041-ca90b380-21da-11eb-9a0e-3671ece1c600.PNG)