### PR TITLE
Add multiple schedule versions & switching interface

### DIFF
--- a/src/components/App/content.tsx
+++ b/src/components/App/content.tsx
@@ -91,6 +91,7 @@ export function AppSkeletonWithLoadingTerms({
         onToggleMenu={openDrawer}
         tabs={NAV_TABS}
         termsState={{ type: 'loading' }}
+        versionsState={{ type: 'loading' }}
       />
       {children}
       <Attribution />
@@ -128,6 +129,7 @@ export function AppSkeletonWithSwitchableTerms({
         onToggleMenu={openDrawer}
         tabs={NAV_TABS}
         termsState={{ type: 'loaded', terms, currentTerm, onChangeTerm }}
+        versionsState={{ type: 'loading' }}
       />
       {children}
       <Attribution />

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -8,7 +8,7 @@ export type ButtonProps = {
   className?: string;
   disabled?: boolean;
   href?: string;
-  onClick?: () => void;
+  onClick?: (e: React.SyntheticEvent<HTMLDivElement>) => void;
   children?: React.ReactNode;
 };
 
@@ -43,7 +43,7 @@ export default function Button({
       tabIndex={0}
       onKeyDown={(event): void => {
         // Intercept enter presses
-        if (event.key === 'Enter' && onClick != null) onClick();
+        if (event.key === 'Enter' && onClick != null) onClick(event);
       }}
       role="button"
     >

--- a/src/components/CombinationContainer/index.tsx
+++ b/src/components/CombinationContainer/index.tsx
@@ -38,9 +38,9 @@ export default function CombinationContainer(): React.ReactElement {
         onChange={(newSortingOptionIndex): void =>
           patchSchedule({ sortingOptionIndex: newSortingOptionIndex })
         }
-        value={sortingOptionIndex}
+        current={sortingOptionIndex}
         options={oscar.sortingOptions.map((sortingOption, i) => ({
-          value: i,
+          id: i,
           label: sortingOption.label,
         }))}
       />

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -25,8 +25,10 @@ export default function Header({
   onToggleMenu,
   tabs,
 }: HeaderProps): React.ReactElement {
-  const [{ term, oscar, pinnedCrns }, { setTerm }] =
-    useContext(ScheduleContext);
+  const [
+    { term, oscar, pinnedCrns, allVersionNames, currentVersionIndex },
+    { setTerm, setCurrentVersion, addNewVersion, deleteVersion, renameVersion },
+  ] = useContext(ScheduleContext);
   const terms = useContext(TermsContext);
   const captureRef = useRef<HTMLDivElement>(null);
 
@@ -53,6 +55,15 @@ export default function Header({
           terms,
           currentTerm: term,
           onChangeTerm: setTerm,
+        }}
+        versionsState={{
+          type: 'loaded',
+          allVersionNames,
+          currentVersionIndex,
+          setCurrentVersion,
+          addNewVersion,
+          deleteVersion,
+          renameVersion,
         }}
       />
 

--- a/src/components/HeaderDisplay/stylesheet.scss
+++ b/src/components/HeaderDisplay/stylesheet.scss
@@ -50,3 +50,8 @@
   // Increase the icon size
   font-size: 1.7rem;
 }
+
+.version-switch {
+  flex-shrink: 1;
+  min-width: 0;
+}

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -1,6 +1,12 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCaretDown } from '@fortawesome/free-solid-svg-icons';
+import {
+  faCaretDown,
+  faCheck,
+  faPlus,
+  faTimes,
+  IconDefinition,
+} from '@fortawesome/free-solid-svg-icons';
 
 import { classes } from '../../utils/misc';
 import { Button } from '..';
@@ -8,50 +14,257 @@ import Spinner from '../Spinner';
 
 import './stylesheet.scss';
 
-export type SelectProps<V extends string | number> = {
+export type SelectProps<Id extends string | number> = {
   className?: string;
-  value: V;
-  onChange: (newValue: V) => void;
-  options: SelectOption<V>[];
+  style?: React.CSSProperties;
+  current: Id;
+  onChange: (newId: Id) => void;
+  options: SelectOption<Id>[];
+  desiredItemWidth?: number | string | null;
+
+  // If this is provided, then an explicit "New" option is added
+  // to the bottom of the <Select> box
+  // that will invoke this callback when clicked.
+  onClickNew?: () => void;
+
+  // Ignored if `onClickNew` is not provided.
+  newLabel?: string;
 };
 
-export type SelectOption<V> = {
-  value: V;
-  label: React.ReactNode;
-};
+export interface SelectOption<Id extends string | number> {
+  id: Id;
+  label: string;
 
-export default function Select<V extends string | number>({
+  // Used to specify any inline actions (buttons)
+  // These are visible when hovering the option on desktop,
+  // and are always visible on mobile.
+  actions?: SelectAction<Id>[];
+}
+
+export type SelectAction<Id extends string | number> =
+  | EditAction<Id>
+  | ButtonAction<Id>;
+
+/**
+ * Action that, when clicked on, initiates inline editing.
+ * Once the user commits the edit (either by pressing 'Enter'
+ * or by clicking the checkbox that this action's icon is replaced with),
+ * then the `onCommit` callback is invoked,
+ * which gives the action the opportunity:
+ * to accept the edit (by updating the item's label and returning true)
+ * or reject it (by returning false).
+ * If the edit is rejected, then the <Select> box remains in edit mode.
+ */
+export interface EditAction<Id extends string | number> {
+  type: 'edit';
+  icon: IconDefinition;
+  onCommit: (newLabel: string, id: Id) => boolean;
+}
+
+/**
+ * Basic action that, when clicked on, invokes the specified `onClick` callback
+ */
+export interface ButtonAction<Id extends string | number> {
+  type: 'button';
+  icon: IconDefinition;
+  onClick: (id: Id) => void;
+}
+
+/**
+ * Renders a combo box-style input element that can be used
+ * to select an option from a small group of options,
+ * where only a single selected item can be active.
+ * Supports per-option actions, inline label editing,
+ * and a "New" option that appears at the bottom of the drop-down list.
+ */
+export default function Select<Id extends string | number>({
   className,
-  value,
+  style,
+  current,
   onChange,
   options,
-}: SelectProps<V>): React.ReactElement {
+  desiredItemWidth = null,
+  onClickNew,
+  newLabel = 'New',
+}: SelectProps<Id>): React.ReactElement {
   const [opened, setOpened] = useState(false);
 
-  const selectedOption = options.find((option) => option.value === value);
+  const selectedOption = options.find((option) => option.id === current);
   const label = selectedOption ? selectedOption.label : '-';
+
+  // Control inline editing state
+  const [inputId, setInputId] = useState<Id | null>(null);
+  const [inputValue, setInputValue] = useState<string>('');
+  const [inputEditAction, setInputEditAction] = useState<EditAction<Id> | null>(
+    null
+  );
+
+  // Try to commit the edit, sending the changes to the provided callback.
+  // If the callback returns `true`, then the edit is ended.
+  // If the callback returns `false`, then the edit is not committed
+  //    and will remain active (for the user to fix the issue).
+  // Does not close the selection box.
+  // Returns whether the commit was successful.
+  const tryCommit = (): boolean => {
+    if (inputEditAction === null) return false;
+    if (inputId === null) return false;
+    const committedValue = inputValue.trim();
+
+    if (inputEditAction.onCommit(committedValue, inputId)) {
+      setInputId(null);
+      setInputValue('');
+      setInputEditAction(null);
+      return true;
+    }
+
+    return false;
+  };
+
+  // Abandon the edit, discarding the changes.
+  // Does not close the selection box.
+  const abandonEdit = (): void => {
+    setInputId(null);
+    setInputValue('');
+    setInputEditAction(null);
+  };
+
+  // Handle when the user presses 'Enter' or 'Escape'
+  // to commit or abandon an in-progress edit, respectively.
+  // If either key is pressed and the operation was successful,
+  // then we also close the Select box.
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+    if (inputEditAction === null) return;
+    if (inputId === null) return;
+
+    if (e.key === 'Enter') {
+      if (tryCommit()) {
+        setOpened(false);
+      }
+    }
+    if (e.key === 'Escape') {
+      abandonEdit();
+      setOpened(false);
+    }
+  };
+
+  // Pass calls to `setOpened` through this,
+  // to block closing the selection box when there is an active edit.
+  const trySetOpened = (newOpened: boolean): void => {
+    // If there is an active edit and the caller is trying
+    // to close the Select box, prevent this
+    if (inputId !== null && !newOpened) return;
+
+    setOpened(newOpened);
+  };
 
   return (
     <div
       className={classes('Button', 'Select', className)}
-      onClick={(): void => setOpened(!opened)}
+      onClick={(): void => trySetOpened(!opened)}
+      style={style}
     >
       <div className="text">{label}</div>
       <FontAwesomeIcon fixedWidth icon={faCaretDown} />
       {opened && (
-        <div className="intercept" onClick={(): void => setOpened(false)} />
+        <div className="intercept" onClick={(): void => trySetOpened(false)} />
       )}
       {opened && (
-        <div className="option-container">
-          {options.map(({ value: optionValue, label: optionLabel }) => (
-            <Button
-              className="option"
-              key={optionValue}
-              onClick={(): void => onChange(optionValue)}
+        <div
+          className="option-container"
+          style={desiredItemWidth != null ? { width: desiredItemWidth } : {}}
+        >
+          {options.map(({ id: optionId, label: optionLabel, actions = [] }) => (
+            <div
+              key={String(optionId)}
+              className={classes(
+                'option',
+                optionId === inputId && 'option-inputting'
+              )}
             >
-              {optionLabel}
-            </Button>
+              {inputId === optionId ? (
+                <AutoFocusInput
+                  className="option-input"
+                  value={inputValue}
+                  onChange={(e): void => setInputValue(e.target.value)}
+                  placeholder={optionLabel}
+                  onKeyDown={handleKeyDown}
+                />
+              ) : (
+                <Button
+                  className="option-text"
+                  key={optionId}
+                  onClick={(): void => onChange(optionId)}
+                >
+                  {optionLabel}
+                </Button>
+              )}
+              {actions.map((action, i) => (
+                <React.Fragment key={i}>
+                  {action.type === 'button' ? (
+                    <Button
+                      className="option-button"
+                      onClick={(e): void => {
+                        e.stopPropagation();
+
+                        // Abandon any in-progress edit
+                        if (inputId !== null) abandonEdit();
+
+                        action.onClick(optionId);
+                      }}
+                    >
+                      <FontAwesomeIcon fixedWidth icon={action.icon} />
+                    </Button>
+                  ) : (
+                    <>
+                      {optionId === inputId ? (
+                        <>
+                          <Button
+                            className="option-button"
+                            onClick={(e): void => {
+                              e.stopPropagation();
+                              tryCommit();
+                            }}
+                          >
+                            <FontAwesomeIcon fixedWidth icon={faCheck} />
+                          </Button>
+                          <Button
+                            className="option-button"
+                            onClick={(e): void => {
+                              e.stopPropagation();
+                              abandonEdit();
+                            }}
+                          >
+                            <FontAwesomeIcon fixedWidth icon={faTimes} />
+                          </Button>
+                        </>
+                      ) : (
+                        <Button
+                          className="option-button"
+                          onClick={(e): void => {
+                            e.stopPropagation();
+                            // Start a new edit (ignore any in-progress edits)
+                            setInputId(optionId);
+                            setInputValue(optionLabel);
+                            setInputEditAction(action);
+                          }}
+                        >
+                          <FontAwesomeIcon fixedWidth icon={action.icon} />
+                        </Button>
+                      )}
+                    </>
+                  )}
+                </React.Fragment>
+              ))}
+            </div>
           ))}
+          {onClickNew !== undefined && (
+            <div className="option">
+              <Button className="option-text" onClick={onClickNew}>
+                <FontAwesomeIcon icon={faPlus} style={{ marginRight: 8 }} />{' '}
+                {newLabel}
+              </Button>
+            </div>
+          )}
         </div>
       )}
     </div>
@@ -63,6 +276,11 @@ export type LoadingSelectProps = {
   label?: string;
 };
 
+/**
+ * Visually similar to a `<Select>` component,
+ * except it cannot be interacted with and displays the given label text
+ * (default: "Loading") next to a small spinner
+ */
 export function LoadingSelect({
   className,
   label = 'Loading',
@@ -73,5 +291,49 @@ export function LoadingSelect({
       <div className="text">{label}</div>
       <FontAwesomeIcon fixedWidth icon={faCaretDown} />
     </div>
+  );
+}
+
+// Private sub-components
+
+type AutoFocusInputProps = {
+  className?: string;
+  style?: React.CSSProperties;
+  value: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  placeholder?: string;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+};
+
+/**
+ * Simple wrapper around `<input>`
+ * that automatically focuses its contents when it is first mounted
+ */
+function AutoFocusInput({
+  className,
+  style,
+  value,
+  onChange,
+  placeholder,
+  onKeyDown,
+}: AutoFocusInputProps): React.ReactElement {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  useEffect(() => {
+    if (inputRef.current === null) return;
+    inputRef.current.focus();
+    inputRef.current.select();
+  }, []);
+
+  return (
+    <input
+      className={className}
+      style={style}
+      value={value}
+      onChange={onChange}
+      placeholder={placeholder}
+      onKeyDown={onKeyDown}
+      ref={inputRef}
+      type="text"
+    />
   );
 }

--- a/src/components/Select/stylesheet.scss
+++ b/src/components/Select/stylesheet.scss
@@ -1,11 +1,20 @@
 @import '../../variables';
 
+$max-item-width: 320px;
+
 .Select {
   position: relative;
   justify-content: space-between;
+  max-width: $max-item-width;
 
   .text {
     margin-right: 8px;
+    overflow: hidden;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex-shrink: 1;
+    flex-grow: 1;
   }
 
   .intercept {
@@ -29,6 +38,7 @@
     top: 100%;
     max-height: 240px;
     overflow-y: auto;
+    max-width: $max-item-width;
 
     @include dark {
       background-color: $theme-dark-card-background;
@@ -39,8 +49,73 @@
     }
 
     .option {
-      justify-content: flex-start;
+      justify-content: center;
+      align-items: stretch;
       white-space: nowrap;
+      padding: 0;
+      display: flex;
+
+      // Include a highlight-hover style on the outer option
+      // so that when hovering over an option with actions,
+      // the (un)mounting of the action buttons
+      // don't cause visible changes in the bounds of the hover highlight.
+      transition: background-color .2s;
+      &:hover {
+        background-color: $color-border;
+      }
+
+      .Button {
+        flex-shrink: 0;
+        flex-grow: 0;
+      }
+
+      .option-text {
+        min-width: 87px;
+        white-space: nowrap;
+        overflow: hidden;
+        display: block;
+        text-overflow: ellipsis;
+        flex-shrink: 1;
+        flex-grow: 1;
+
+        // Disable the highlight-on-hover styles for the main button
+        background-color: transparent;
+      }
+
+      .option-button {
+        padding: 4px;
+        display: none;
+        width: 36px;
+      }
+
+      .option-input {
+        padding: 8px;
+        margin: 4px;
+        flex-shrink: 1;
+        flex-grow: 1;
+        width: 0;
+
+        .dark & {
+          background-color: rgba(255, 255, 255, 0.1);
+        }
+
+        .light & {
+          background-color: rgba(0, 0, 0, 0.075);
+        }
+      }
+
+      &:hover,
+      &.option-inputting {
+        .option-button {
+          display: flex;
+        }
+      }
+
+      @media (hover: none), (max-width: 900px) {
+        .option-button {
+          display: flex;
+        }
+      }
     }
   }
 

--- a/src/contexts/schedule.ts
+++ b/src/contexts/schedule.ts
@@ -6,10 +6,16 @@ import { EMPTY_OSCAR } from '../data/beans/Oscar';
 import { defaultSchedule, Schedule } from '../data/types';
 import { ErrorWithFields } from '../log';
 
-export type ScheduleContextData = Immutable<Schedule> & {
-  readonly term: string;
-  readonly oscar: Oscar;
+type ExtraData = {
+  term: string;
+  currentVersionIndex: number;
+  allVersionNames: string[];
+  // `oscar` is included below as a separate type
 };
+
+export type ScheduleContextData = Immutable<Schedule> &
+  // `Oscar` can't go into `Immutable`, so we place it separately
+  Immutable<ExtraData> & { readonly oscar: Oscar };
 
 export type ScheduleContextSetters = {
   setTerm: (next: string) => void;
@@ -17,6 +23,10 @@ export type ScheduleContextSetters = {
   updateSchedule: (
     applyDraft: (draft: Draft<Schedule>) => void | Immutable<Schedule>
   ) => void;
+  setCurrentVersion: (nextIndex: number) => void;
+  addNewVersion: (name: string, select?: boolean) => void;
+  deleteVersion: (index: number) => void;
+  renameVersion: (index: number, newName: string) => void;
 };
 export type ScheduleContextValue = [
   ScheduleContextData,
@@ -25,6 +35,8 @@ export type ScheduleContextValue = [
 export const ScheduleContext = React.createContext<ScheduleContextValue>([
   {
     term: '',
+    currentVersionIndex: 0,
+    allVersionNames: [],
     oscar: EMPTY_OSCAR,
     ...defaultSchedule,
   },
@@ -48,6 +60,40 @@ export const ScheduleContext = React.createContext<ScheduleContextValue>([
     updateSchedule: (): void => {
       throw new ErrorWithFields({
         message: 'empty ScheduleContext.updateSchedule value being used',
+      });
+    },
+    setCurrentVersion: (nextIndex: number): void => {
+      throw new ErrorWithFields({
+        message: 'empty ScheduleContext.setCurrentVersion value being used',
+        fields: {
+          nextIndex,
+        },
+      });
+    },
+    addNewVersion: (name: string, select?: boolean): void => {
+      throw new ErrorWithFields({
+        message: 'empty ScheduleContext.addNewVersion value being used',
+        fields: {
+          name,
+          select,
+        },
+      });
+    },
+    deleteVersion: (index: number): void => {
+      throw new ErrorWithFields({
+        message: 'empty ScheduleContext.deleteVersion value being used',
+        fields: {
+          index,
+        },
+      });
+    },
+    renameVersion: (index: number, newName: string): void => {
+      throw new ErrorWithFields({
+        message: 'empty ScheduleContext.renameVersion value being used',
+        fields: {
+          index,
+          newName,
+        },
       });
     },
   },

--- a/src/data/hooks/useVersionActions.ts
+++ b/src/data/hooks/useVersionActions.ts
@@ -1,0 +1,139 @@
+import { castDraft, Draft, Immutable } from 'immer';
+import { useCallback } from 'react';
+
+import { softError, ErrorWithFields } from '../../log';
+import { defaultSchedule, TermScheduleData } from '../types';
+
+export type HookResult = {
+  setCurrentVersion: (nextIndex: number) => void;
+  addNewVersion: (name: string, select?: boolean) => void;
+  deleteVersion: (index: number) => void;
+  renameVersion: (index: number, newName: string) => void;
+};
+
+/**
+ * Creates a small handful of semantic actions that update the schedule versions
+ * from the base `updateTermScheduleData` callback.
+ */
+export default function useVersionActions({
+  updateTermScheduleData,
+}: {
+  updateTermScheduleData: (
+    applyDraft: (
+      draft: Draft<TermScheduleData>
+    ) => void | Immutable<TermScheduleData>
+  ) => void;
+}): HookResult {
+  // Create a `setCurrentVersion` function
+  const setCurrentVersion = useCallback(
+    (nextIndex: number): void => {
+      updateTermScheduleData((draft) => {
+        draft.currentIndex = nextIndex;
+      });
+    },
+    [updateTermScheduleData]
+  );
+
+  // Create an `addNewVersion` function
+  const addNewVersion = useCallback(
+    (name: string, select = false): void => {
+      updateTermScheduleData((draft) => {
+        draft.versions.push({ name, schedule: castDraft(defaultSchedule) });
+        if (select) {
+          draft.currentIndex = draft.versions.length - 1;
+        }
+      });
+    },
+    [updateTermScheduleData]
+  );
+
+  // Create a `deleteVersion` function
+  const deleteVersion = useCallback(
+    (index: number): void => {
+      updateTermScheduleData((draft) => {
+        if (index < 0 || index > draft.versions.length - 1) {
+          softError(
+            new ErrorWithFields({
+              message:
+                'deleteVersion called with out-of-bounds version index; ignoring',
+              fields: {
+                allVersionNames: draft.versions.map(({ name }) => name),
+                versionCount: draft.versions.length,
+                index,
+              },
+            })
+          );
+          return;
+        }
+
+        draft.versions.splice(index, 1);
+
+        // Check to see if we also need to assign a new current version.
+        // This is the case if either:
+        // - the current index is after the deleted index,
+        //   in which case everything got shifted to the left
+        //   so we need to change the current version's index to be 1 less
+        // - the current index is the deleted index,
+        //   in which case we want to select the previous item
+        //   (this is arbitrary; it's just our decided behavior)
+        if (draft.currentIndex >= index) {
+          // Select the previous version if we can
+          const newIndex = Math.max(draft.currentIndex - 1, 0);
+          if (draft.versions.length === 0) {
+            // The versions list is empty:
+            // create a new version called 'Primary'
+            draft.currentIndex = 0;
+            draft.versions.push({
+              name: 'Primary',
+              schedule: castDraft(defaultSchedule),
+            });
+            return;
+          }
+
+          // If the versions list isn't empty, then this index must be valid
+          draft.currentIndex = newIndex;
+        }
+      });
+    },
+    [updateTermScheduleData]
+  );
+
+  // Create a `renameVersion` function
+  const renameVersion = useCallback(
+    (index: number, newName: string): void => {
+      updateTermScheduleData((draft) => {
+        const reportNotExists = (): void => {
+          softError(
+            new ErrorWithFields({
+              message:
+                "renameVersion called with current version name that doesn't exist; ignoring",
+              fields: {
+                allVersions: Object.keys(draft.versions),
+                index,
+                allVersionNames: draft.versions.map(({ name }) => name),
+                versionCount: draft.versions.length,
+                newName,
+              },
+            })
+          );
+        };
+
+        if (index < 0 || index > draft.versions.length - 1) {
+          reportNotExists();
+          return;
+        }
+
+        const existingDraft = draft.versions[index];
+        if (existingDraft === undefined) {
+          reportNotExists();
+          return;
+        }
+
+        existingDraft.name = newName;
+      });
+    },
+    [updateTermScheduleData]
+  );
+
+  return { setCurrentVersion, addNewVersion, deleteVersion, renameVersion };
+}

--- a/src/hooks/useFeatureFlag.ts
+++ b/src/hooks/useFeatureFlag.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Used to gate certain features behind opt-in developer feature flags.
+ * These are stored in local storage, and can be enabled by setting to `true`
+ * the local storage item with a key in the pattern of `ff-${date}-${key}`
+ */
+export default function useFeatureFlag(date: string, key: string): boolean {
+  const derivedKey = `ff-${date}-${key}`;
+  const [isEnabled, setIsEnabled] = useState<boolean>(() => {
+    try {
+      if (window.localStorage.getItem(derivedKey) === 'true') return true;
+      return false;
+    } catch (_) {
+      // Ignore
+      return false;
+    }
+  });
+
+  // Subscribe to updates
+  useEffect(() => {
+    const listener = (event: StorageEvent): void => {
+      try {
+        if (event.storageArea === localStorage && event.key === derivedKey) {
+          setIsEnabled(event.newValue === 'true');
+        }
+      } catch (_) {
+        // Ignore
+      }
+    };
+
+    try {
+      window.addEventListener('storage', listener, false);
+      return (): void => {
+        try {
+          window.removeEventListener('storage', listener, false);
+        } catch (_) {
+          // Ignore
+        }
+      };
+    } catch (_) {
+      // Ignore
+      return (): void => undefined;
+    }
+  });
+
+  return isEnabled;
+}

--- a/src/stylesheet.scss
+++ b/src/stylesheet.scss
@@ -157,6 +157,10 @@ body.light {
   }
 }
 
+.swal-button-container {
+  margin: 0 8px;
+}
+
 .swal-button {
   box-shadow: 0px 0px 20px #00000033;
   transition: all 0.33s ease;

--- a/src/utils/misc.test.ts
+++ b/src/utils/misc.test.ts
@@ -1,0 +1,110 @@
+import { getNextVersionName } from './misc';
+
+describe('getNextVersionName', () => {
+  it('returns Primary if the list is empty', () => {
+    expect(getNextVersionName([])).toEqual('Primary');
+  });
+
+  it('returns elements in the sequence', () => {
+    const tests = [
+      {
+        input: ['Primary'],
+        expected: 'Secondary',
+      },
+      {
+        input: ['Primary', 'Secondary'],
+        expected: 'Tertiary',
+      },
+      {
+        input: ['Primary', 'Secondary', 'Tertiary'],
+        expected: 'Quaternary',
+      },
+      {
+        input: ['Primary', 'Secondary', 'Tertiary', 'Quaternary'],
+        expected: 'Quinary',
+      },
+      {
+        input: ['Primary', 'Secondary', 'Tertiary', 'Quaternary', 'Quinary'],
+        expected: 'Senary',
+      },
+      {
+        input: [
+          'Primary',
+          'Secondary',
+          'Tertiary',
+          'Quaternary',
+          'Quinary',
+          'Senary',
+        ],
+        expected: 'Septenary',
+      },
+      {
+        input: [
+          'Primary',
+          'Secondary',
+          'Tertiary',
+          'Quaternary',
+          'Quinary',
+          'Senary',
+          'Septenary',
+        ],
+        expected: 'Octonary',
+      },
+      {
+        input: [
+          'Primary',
+          'Secondary',
+          'Tertiary',
+          'Quaternary',
+          'Quinary',
+          'Senary',
+          'Septenary',
+          'Octonary',
+        ],
+        expected: 'Nonary',
+      },
+      {
+        input: [
+          'Primary',
+          'Secondary',
+          'Tertiary',
+          'Quaternary',
+          'Quinary',
+          'Senary',
+          'Septenary',
+          'Octonary',
+          'Nonary',
+        ],
+        expected: 'Denary',
+      },
+    ];
+
+    tests.forEach(({ input, expected }) => {
+      expect(getNextVersionName(input)).toEqual(expected);
+    });
+  });
+
+  it("doesn't return Primary if the list is non-empty", () => {
+    expect(getNextVersionName(['SomeOtherVersionName'])).toEqual('Secondary');
+    expect(getNextVersionName(['SomeOtherVersionName', 'Secondary'])).toEqual(
+      'Tertiary'
+    );
+  });
+
+  it('returns a fallback if the default names are exhausted', () => {
+    expect(
+      getNextVersionName([
+        'Primary',
+        'Secondary',
+        'Tertiary',
+        'Quaternary',
+        'Quinary',
+        'Senary',
+        'Septenary',
+        'Octonary',
+        'Nonary',
+        'Denary',
+      ])
+    ).toEqual('New version');
+  });
+});

--- a/src/utils/misc.tsx
+++ b/src/utils/misc.tsx
@@ -305,3 +305,40 @@ export function downloadShadowCalendar(
       )
     );
 }
+
+export const PRIMARY_VERSION_NAME = 'Primary';
+const OTHER_VERSIONS_NAMES = [
+  'Secondary',
+  'Tertiary',
+  'Quaternary',
+  'Quinary',
+  'Senary',
+  'Septenary',
+  'Octonary',
+  'Nonary',
+  'Denary',
+];
+
+/**
+ * Gets the next auto-generated version name in the sequence of
+ * Primary, Secondary, Tertiary, ...
+ * all the way up to the name for the 10th item (Denary)
+ * before returning "New version".
+ * If the array is empty, then it always returns 'Primary'.
+ * Otherwise, it will return the first item in the sequence,
+ * starting with 'Secondary' (meaning that it will always skip 'Primary',
+ * even if it's not an element in the given list)
+ */
+export function getNextVersionName(allVersionNames: readonly string[]): string {
+  const allNamesSet: Set<string> = new Set(allVersionNames);
+  if (allNamesSet.size === 0) return PRIMARY_VERSION_NAME;
+
+  for (const version of OTHER_VERSIONS_NAMES) {
+    if (!allNamesSet.has(version)) {
+      return version;
+    }
+  }
+
+  // Fall back to the default with over 10 versions
+  return 'New version';
+}


### PR DESCRIPTION
### Summary

This pull request addresses issue #11, adding the functionality of creating multiple schedules for each term. It accomplishes this by modifying `<Select>` to support additional UI interaction patterns, such as:

- A "new" option at the bottom to create a new item
- In-line "action" buttons controllable on a per-option basis
- In-line editing functionality, with the ability for the user to edit the label of an option and then commit/abandon the edit.

The PR merges this functionality behind a feature flag that will be removed in the future closer to when the course catalog for Spring 2022 is released (fully launching the feature).

### Motivation

#11 is one of the most commonly-requested features for the app (see #41), so implementing it should be very beneficial to our users.

### Contributors

- @kw143 
- @jazevedo620 
