### PR TITLE
Feature/overlapping blocks

### DIFF
--- a/src/components/Calendar/index.js
+++ b/src/components/Calendar/index.js
@@ -19,7 +19,15 @@ export default function Calendar({
     return acc;
   }, {});
 
-  [...new Set([...pinnedCrns, ...(overlayCrns || [])])].forEach((crn) => {
+  const crns = [...new Set([...pinnedCrns, ...(overlayCrns || [])])];
+  const meetingLen = (m) => m.period.end - m.period.start;
+  crns.sort(
+    (a, b) =>
+      Math.max(...oscar.findSection(a).meetings.map(meetingLen)) -
+      Math.max(...oscar.findSection(b).meetings.map(meetingLen))
+  );
+
+  crns.forEach((crn) => {
     oscar.findSection(crn).meetings.forEach((meeting) => {
       meeting.days.forEach((day) => {
         let curRowSize = 1;

--- a/src/components/Calendar/index.js
+++ b/src/components/Calendar/index.js
@@ -13,12 +13,12 @@ export default function Calendar({
   isAutosized
 }) {
   const [{ pinnedCrns, oscar }] = useContext(TermContext);
-  
+
   const dayMap = DAYS.reduce((acc, day) => {
     acc[day] = {};
     return acc;
   }, {});
-  
+
   [...new Set([...pinnedCrns, ...(overlayCrns || [])])].forEach((crn) => {
     oscar.findSection(crn).meetings.forEach((meeting) => {
       meeting.days.forEach((day) => {
@@ -26,7 +26,10 @@ export default function Calendar({
         let isSingle = true;
 
         for (const entry of Object.values(dayMap[day])) {
-          if (entry.period.start < meeting.period.end && entry.period.end > meeting.period.start) {
+          if (
+            entry.period.start < meeting.period.end &&
+            entry.period.end > meeting.period.start
+          ) {
             curRowSize = Math.max(curRowSize, entry.rowSize + 1);
             isSingle = false;
             entry.single = false;
@@ -38,18 +41,34 @@ export default function Calendar({
             return;
           }
           seen.add(curCrn);
-          
+
           for (const entry of arr) {
-            if (entry.period.start < curPeriod.end && entry.period.end > curPeriod.start) {
+            if (
+              entry.period.start < curPeriod.end &&
+              entry.period.end > curPeriod.start
+            ) {
               entry.rowSize = curRowSize;
               updatePrevious(arr, seen, entry.crn, entry.period);
             }
           }
-        }
+        };
 
-        updatePrevious(Object.values(dayMap[day]), new Set(), crn, meeting.period);
-        
-        dayMap[day][[crn, meeting.period.start, meeting.period.end].join('-')] = { crn: crn, period: meeting.period, single: isSingle, rowIndex: curRowSize - 1, rowSize: curRowSize };
+        updatePrevious(
+          Object.values(dayMap[day]),
+          new Set(),
+          crn,
+          meeting.period
+        );
+
+        dayMap[day][
+          [crn, meeting.period.start, meeting.period.end].join('-')
+        ] = {
+          crn,
+          period: meeting.period,
+          single: isSingle,
+          rowIndex: curRowSize - 1,
+          rowSize: curRowSize
+        };
       });
     });
   });

--- a/src/components/Calendar/index.js
+++ b/src/components/Calendar/index.js
@@ -31,18 +31,16 @@ export default function Calendar({
     oscar.findSection(crn).meetings.forEach((meeting) => {
       meeting.days.forEach((day) => {
         let curRowSize = 1;
-        let isSingle = true;
 
-        for (const entry of Object.values(dayMap[day])) {
-          if (
-            entry.period.start < meeting.period.end &&
-            entry.period.end > meeting.period.start
-          ) {
+        Object.values(dayMap[day])
+          .filter(
+            (entry) =>
+              entry.period.start < meeting.period.end &&
+              entry.period.end > meeting.period.start
+          )
+          .forEach((entry) => {
             curRowSize = Math.max(curRowSize, entry.rowSize + 1);
-            isSingle = false;
-            entry.single = false;
-          }
-        }
+          });
 
         const updatePrevious = (arr, seen, curCrn, curPeriod) => {
           if (seen.has(curCrn)) {
@@ -50,15 +48,16 @@ export default function Calendar({
           }
           seen.add(curCrn);
 
-          for (const entry of arr) {
-            if (
-              entry.period.start < curPeriod.end &&
-              entry.period.end > curPeriod.start
-            ) {
+          arr
+            .filter(
+              (entry) =>
+                entry.period.start < curPeriod.end &&
+                entry.period.end > curPeriod.start
+            )
+            .forEach((entry) => {
               entry.rowSize = curRowSize;
               updatePrevious(arr, seen, entry.crn, entry.period);
-            }
-          }
+            });
         };
 
         updatePrevious(
@@ -73,7 +72,6 @@ export default function Calendar({
         ] = {
           crn,
           period: meeting.period,
-          single: isSingle,
           rowIndex: curRowSize - 1,
           rowSize: curRowSize
         };

--- a/src/components/Calendar/index.js
+++ b/src/components/Calendar/index.js
@@ -43,17 +43,13 @@ export default function Calendar({
       .meetings.filter((m) => m.period)
       .forEach((meeting) => {
         meeting.days.forEach((day) => {
-          let curRowSize = 1;
-
-          Object.values(dayMap[day])
+          const curRowSize = Object.values(dayMap[day])
             .filter(
               (entry) =>
                 entry.period.start < meeting.period.end &&
                 entry.period.end > meeting.period.start
             )
-            .forEach((entry) => {
-              curRowSize = Math.max(curRowSize, entry.rowSize + 1);
-            });
+            .reduce((acc, entry) => Math.max(acc, entry.rowSize + 1), 1);
 
           const updatePrevious = (arr, seen, curCrn, curPeriod) => {
             if (seen.has(curCrn)) {

--- a/src/components/TimeBlocks/index.js
+++ b/src/components/TimeBlocks/index.js
@@ -47,15 +47,9 @@ export default function TimeBlocks({
                 }%`,
                 width: `${
                   20 /
-                  (dayMap[day][
+                  dayMap[day][
                     [crn, meeting.period.start, meeting.period.end].join('-')
-                  ].single
-                    ? 1
-                    : dayMap[day][
-                        [crn, meeting.period.start, meeting.period.end].join(
-                          '-'
-                        )
-                      ].rowSize)
+                  ].rowSize
                 }%`,
                 left: `${
                   DAYS.indexOf(day) * 20 +

--- a/src/components/TimeBlocks/index.js
+++ b/src/components/TimeBlocks/index.js
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import ReactTooltip from 'react-tooltip';
 import { classes, getContentClassName, periodToString } from '../../utils';
-import { CLOSE, OPEN } from '../../constants';
+import { CLOSE, OPEN, DAYS } from '../../constants';
 import './stylesheet.scss';
 import { TermContext } from '../../contexts';
 
@@ -11,7 +11,8 @@ export default function TimeBlocks({
   overlay,
   preview,
   capture,
-  isAutosized
+  isAutosized,
+  dayMap
 }) {
   const [{ oscar, colorMap }] = useContext(TermContext);
 
@@ -43,6 +44,16 @@ export default function TimeBlocks({
                   ((meeting.period.end - meeting.period.start) /
                     (CLOSE - OPEN)) *
                   100
+                }%`,
+                width: `${
+                  20 / (dayMap[day][[crn, meeting.period.start, meeting.period.end].join('-')].single ?
+                    1 :
+                    dayMap[day][[crn, meeting.period.start, meeting.period.end].join('-')].rowSize)
+                }%`,
+                left: `${
+                  DAYS.indexOf(day) * 20 +
+                  (dayMap[day][[crn, meeting.period.start, meeting.period.end].join('-')].rowIndex *
+                    (20 / dayMap[day][[crn, meeting.period.start, meeting.period.end].join('-')].rowSize))
                 }%`,
                 backgroundColor: color
               }}

--- a/src/components/TimeBlocks/index.js
+++ b/src/components/TimeBlocks/index.js
@@ -46,14 +46,28 @@ export default function TimeBlocks({
                   100
                 }%`,
                 width: `${
-                  20 / (dayMap[day][[crn, meeting.period.start, meeting.period.end].join('-')].single ?
-                    1 :
-                    dayMap[day][[crn, meeting.period.start, meeting.period.end].join('-')].rowSize)
+                  20 /
+                  (dayMap[day][
+                    [crn, meeting.period.start, meeting.period.end].join('-')
+                  ].single
+                    ? 1
+                    : dayMap[day][
+                        [crn, meeting.period.start, meeting.period.end].join(
+                          '-'
+                        )
+                      ].rowSize)
                 }%`,
                 left: `${
                   DAYS.indexOf(day) * 20 +
-                  (dayMap[day][[crn, meeting.period.start, meeting.period.end].join('-')].rowIndex *
-                    (20 / dayMap[day][[crn, meeting.period.start, meeting.period.end].join('-')].rowSize))
+                  dayMap[day][
+                    [crn, meeting.period.start, meeting.period.end].join('-')
+                  ].rowIndex *
+                    (20 /
+                      dayMap[day][
+                        [crn, meeting.period.start, meeting.period.end].join(
+                          '-'
+                        )
+                      ].rowSize)
                 }%`,
                 backgroundColor: color
               }}

--- a/src/components/TimeBlocks/index.js
+++ b/src/components/TimeBlocks/index.js
@@ -12,7 +12,7 @@ export default function TimeBlocks({
   preview,
   capture,
   isAutosized,
-  dayMap
+  sizeInfo
 }) {
   const [{ oscar, colorMap }] = useContext(TermContext);
 
@@ -47,20 +47,18 @@ export default function TimeBlocks({
                 }%`,
                 width: `${
                   20 /
-                  dayMap[day][
-                    [crn, meeting.period.start, meeting.period.end].join('-')
+                  sizeInfo[day][
+                    [meeting.period.start, meeting.period.end].join('-')
                   ].rowSize
                 }%`,
                 left: `${
                   DAYS.indexOf(day) * 20 +
-                  dayMap[day][
-                    [crn, meeting.period.start, meeting.period.end].join('-')
+                  sizeInfo[day][
+                    [meeting.period.start, meeting.period.end].join('-')
                   ].rowIndex *
                     (20 /
-                      dayMap[day][
-                        [crn, meeting.period.start, meeting.period.end].join(
-                          '-'
-                        )
+                      sizeInfo[day][
+                        [meeting.period.start, meeting.period.end].join('-')
                       ].rowSize)
                 }%`,
                 backgroundColor: color

--- a/src/components/TimeBlocks/stylesheet.scss
+++ b/src/components/TimeBlocks/stylesheet.scss
@@ -55,6 +55,7 @@
       .ids {
         display: flex;
         font-weight: bold;
+        overflow: hidden;
 
         span {
           font-size: .8em;


### PR DESCRIPTION
#### This pull request adds functionality to allow overlapping time blocks to be visually separated from each other (similarly to courseoff).

#### Reason for Feature
Personally, when I make my schedule I tend to pin every section time possible onto my calendar so that I can visually see my options, then I slowly whittle down my selections until I get only one section per course. When switching to gt-scheduler this semester from courseoff, I noticed this approach is difficult when times partially overlap and impossible when they fully overlap.

#### Changes Implemented
1. Within every day, whenever courses time blocks overlap, I modify their 'width' and 'left' CSS properties to make each of these blocks less wide and horizontally separated.
2. Unlike courseoff, I do this in a way so that you can have a grouping of overlapping blocks at the top of the day, each with a width of say 1/3, and have a disjoint grouping of overlapping blocks at the bottom of the day, each with a width of say 1/2.
3. JustinH11235@7fab9359b75a790bceeae17019d3db492b9e0d39 sorts the pinned/overlayCrns from shortest to tallest as a heuristic that attempts to fit the blocks together in a way that minimizes the number of blocks in a row (not necessary but will show before/after pictures below).
#### Note: If users are only selecting classes that do not overlap (i.e. they should each fill the full row), the blocks will look exactly the same with this PR as without this PR. These changes only visually affect time blocks that would normally overlap each other.

## Before PR
![schedulerold1](https://user-images.githubusercontent.com/61996677/112883280-136adb00-909c-11eb-9eda-5ea93bccd1f7.png)

## After PR (without Heuristic) (same courses as before)
Circled in red are cases where we fit the blocks together inefficiently, causing each block's width to be smaller.
![schedulernew3](https://user-images.githubusercontent.com/61996677/112883690-9f7d0280-909c-11eb-8da9-647a25109239.png)


## After PR (with Heuristic)
![schedulernew1](https://user-images.githubusercontent.com/61996677/112881716-051bbf80-909a-11eb-8b86-d4264425993d.png)

I believe this is a necessary feature for many users, but if you have any critiques, additions, changes, etc. please let me know! Also, I am new to open-source contributing so please let me know if I'm doing anything wrong and I'll try to fix it. Hope this is helpful!