### PR TITLE
Better utilize TS in Prerequisite component to separate component variants

### DIFF
--- a/src/components/Course/index.tsx
+++ b/src/components/Course/index.tsx
@@ -13,7 +13,7 @@ import { classes, getContentClassName } from '../../utils';
 import { ActionRow, Instructor, Palette, Prerequisite } from '..';
 import { TermContext } from '../../contexts';
 import { Course as CourseBean, Section } from '../../beans';
-import { CourseGpa, PrerequisiteClause, PrerequisiteSet } from '../../types';
+import { CourseGpa, CrawlerPrerequisites } from '../../types';
 import { ErrorWithFields, softError } from '../../log';
 
 import './stylesheet.scss';
@@ -96,20 +96,9 @@ export default function Course({
   const contentClassName = color != null && getContentClassName(color);
 
   const hasPrereqs = oscar.version > 1;
-  let prereqOptions: PrerequisiteClause[] | null = null;
-
+  let prereqs: CrawlerPrerequisites | null = null;
   if (hasPrereqs) {
-    const rawPrereqs = course.prereqs;
-    if (rawPrereqs != null && rawPrereqs.length > 0) {
-      // We just checked the length, so `rawPrereqs` can't be the empty array []
-      // Therefore, it must be `PrerequisiteSet`.
-      const [rootOperator, ...clauses] = rawPrereqs as PrerequisiteSet;
-      if (rootOperator === 'or') {
-        prereqOptions = clauses;
-      } else {
-        prereqOptions = [[rootOperator, ...clauses]];
-      }
-    }
+    prereqs = course.prereqs ?? [];
   }
 
   const instructorMap: Record<string, Section[] | undefined> = {};
@@ -270,32 +259,8 @@ export default function Course({
           )}
         </div>
       )}
-      {expanded && prereqOpen && (
-        <div className={classes('hover-container')}>
-          <div
-            className={classes(
-              !desiredCourses.includes(course.id) && 'dark-content',
-              'nested'
-            )}
-          >
-            <Prerequisite course={course} isHeader />
-            <div className={classes('nested')}>
-              {prereqOptions !== null &&
-                prereqOptions.map((req, i) => (
-                  <Prerequisite
-                    key={i}
-                    option={i + 1}
-                    course={course}
-                    req={req}
-                    isHeader
-                  />
-                ))}
-              {prereqOptions === null && (
-                <Prerequisite course={course} isEmpty />
-              )}
-            </div>
-          </div>
-        </div>
+      {expanded && prereqOpen && prereqs !== null && (
+        <Prerequisite course={course} prereqs={prereqs} />
       )}
     </div>
   );

--- a/src/components/NavMenu/index.tsx
+++ b/src/components/NavMenu/index.tsx
@@ -29,6 +29,7 @@ export default function NavMenu({
         <Button
           className={classes('nav-button', currentItem === idx && 'active')}
           onClick={(): void => onChangeItem(idx)}
+          key={idx}
         >
           {item}
         </Button>

--- a/src/components/Prerequisite/index.tsx
+++ b/src/components/Prerequisite/index.tsx
@@ -6,82 +6,234 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 
 import { TermContext } from '../../contexts';
-import { classes, decryptReqs } from '../../utils';
+import { classes, serializePrereqs } from '../../utils';
 import { ActionRow } from '..';
 import { Course } from '../../beans';
-import { PrerequisiteClause } from '../../types';
+import {
+  CrawlerPrerequisites,
+  PrerequisiteClause,
+  PrerequisiteOperator,
+} from '../../types';
+import { ErrorWithFields, softError } from '../../log';
+
+const BASE_ITEM_STYLE = { fontSize: '0.9em', padding: '8px' };
 
 export type PrerequisiteProps = {
-  course?: Course;
-  option?: number;
-  req?: PrerequisiteClause;
-  isHeader?: boolean;
-  isEmpty?: boolean;
-  isLast?: boolean;
+  course: Course;
+  prereqs: CrawlerPrerequisites;
 };
 
+/**
+ * Renders the prereqs for a single course, given that the crawler version
+ * supports prereqs. (Make sure to check this before). An empty prereq list is
+ * an authoritative statement that the course has no prereqs, and as such a
+ * message will be displayed telling the user. Otherwise, this component tries
+ * to render the prereq tree in a way that is easily consumable without taking
+ * up too much screen space, first trying to split the prereqs up into separate
+ * "options" (sub-clauses of an OR set) if possible before rendering a list of
+ * items with operators in between. Finally, in each item, there is the
+ * flattened textual representation of the remainder of the subtree, which
+ * restores parentheses groupings (much like the original Oscar prereq syntax)
+ */
 export default function Prerequisite({
   course,
-  req,
-  option,
-  isHeader = false,
-  isEmpty = false,
-  isLast = false,
+  prereqs,
 }: PrerequisiteProps): React.ReactElement {
-  const [{ term }] = useContext(TermContext);
-  const [expanded, setExpanded] = useState(true);
-  const reqStyle = { fontSize: '0.9em', padding: '8px' };
+  let content: React.ReactNode;
+  if (prereqs.length === 0) {
+    content = <PrerequisiteEmpty />;
+  } else {
+    // `prereqs` isn't an empty array, so it must be `PrerequisiteSet`
+    // (here we manually `Exclude` the empty array case)
+    const [op, ...subClauses] = prereqs as Exclude<CrawlerPrerequisites, []>;
 
-  const subreqs: PrerequisiteClause[] | null =
-    typeof req === 'undefined'
-      ? []
-      : !Array.isArray(req)
-      ? [req]
-      : typeof req[0] !== 'object'
-      ? (req.slice(1, req.length) as PrerequisiteClause[])
-      : typeof req[0] === 'object'
-      ? [req]
-      : null;
+    switch (op) {
+      case 'and':
+        // We only consider this a single "option",
+        // so just render the content as a direct child
+        content = <PrerequisiteClauseDisplay clause={['and', ...subClauses]} />;
+        break;
+      case 'or':
+        if (subClauses.length === 1) {
+          // There is only 1 option:
+          // just render the content as a direct child
+          content = (
+            <PrerequisiteClauseDisplay
+              clause={subClauses[0] as PrerequisiteClause}
+            />
+          );
+        } else {
+          // Render an option for each sub-clause
+          content = (
+            <>
+              {subClauses.map((subClause, i) => (
+                <PrerequisiteOption key={i} clause={subClause} index={i} />
+              ))}
+            </>
+          );
+        }
+        break;
+      default:
+        softError(
+          new ErrorWithFields({
+            message: 'invalid operator found in top-level prereqs',
+            fields: {
+              courseId: course.id,
+              operator: op,
+            },
+          })
+        );
+        content = null;
+    }
+  }
 
   return (
-    <div>
-      {!isHeader && !isEmpty && req && (
-        <div style={reqStyle}>
-          {decryptReqs(req)} {!isLast && <strong>and</strong>}
+    <div className={classes('hover-container', 'nested')}>
+      <PrerequisiteHeader course={course} />
+      <div className={classes('nested')}>{content}</div>
+    </div>
+  );
+}
+
+// Private sub-components
+
+type PrerequisiteHeaderProps = {
+  course: Course;
+};
+
+/**
+ * Renders the "header" at the top of a prereq display,
+ * which includes a link to Oscar giving the original prereq source,
+ * plus other course information.
+ */
+function PrerequisiteHeader({
+  course,
+}: PrerequisiteHeaderProps): React.ReactElement {
+  const [{ term }] = useContext(TermContext);
+
+  return (
+    <ActionRow
+      className={classes('hover-container')}
+      label="Prerequisites"
+      actions={[
+        {
+          icon: faInfoCircle,
+          href:
+            `https://oscar.gatech.edu/pls/bprod/bwckctlg.p_disp_` +
+            `course_detail?cat_term_in=${term}&subj_code_in=` +
+            `${course.subject}&crse_numb_in=${course.number}`,
+        },
+      ]}
+    />
+  );
+}
+
+type PrerequisiteOptionProps = {
+  clause: PrerequisiteClause;
+  index: number;
+};
+
+/**
+ * Renders a single prereq option -- a sub-clause of a larger "OR" prereq set
+ * that is independently collapse-able from the other sibling options.
+ * Inside, uses `PrerequisiteClauseDisplay` to render the sub-clause if
+ * the option is expanded.
+ */
+function PrerequisiteOption({
+  clause,
+  index,
+}: PrerequisiteOptionProps): React.ReactElement {
+  const [expanded, setExpanded] = useState(true);
+
+  return (
+    <>
+      <ActionRow
+        className={classes('hover-container')}
+        label={`Option ${index + 1}`}
+        actions={[
+          {
+            icon: expanded ? faAngleUp : faAngleDown,
+            onClick: (): void => setExpanded(!expanded),
+          },
+        ]}
+      />
+      {expanded && (
+        <div className={classes('nested')}>
+          <PrerequisiteClauseDisplay clause={clause} />
         </div>
       )}
-      {isHeader && course != null && (
-        <ActionRow
-          className={classes('hover-container')}
-          label={req ? `Option ${option ?? '?'}` : `Prerequisites`}
-          actions={[
-            !req
-              ? {
-                  icon: faInfoCircle,
-                  href:
-                    `https://oscar.gatech.edu/pls/bprod/bwckctlg.p_disp_` +
-                    `course_detail?cat_term_in=${term}&subj_code_in=` +
-                    `${course.subject}&crse_numb_in=${course.number}`,
-                }
-              : null,
-            req && {
-              icon: expanded ? faAngleUp : faAngleDown,
-              onClick: (): void => setExpanded(!expanded),
-            },
-          ]}
+    </>
+  );
+}
+
+type PrerequisiteClauseDisplayProps = {
+  clause: PrerequisiteClause;
+};
+
+/**
+ * Renders an arbitrary prereq clause. If the clause is a singular course,
+ * then it renders a single Item. Otherwise, if the clause is a set,
+ * this component renders an item for each member of the set, and includes
+ * an operator at the end of each item's text to indicate that each item
+ * is part of a larger prereq set.
+ */
+function PrerequisiteClauseDisplay({
+  clause,
+}: PrerequisiteClauseDisplayProps): React.ReactElement {
+  if (!Array.isArray(clause)) {
+    // Render the single prereq course
+    return <PrerequisiteItem clause={clause} operator="and" isLast />;
+  }
+
+  // Render a list of prereq items
+  const [operator, ...subClauses] = clause;
+  return (
+    <>
+      {subClauses.map((subClause, i) => (
+        <PrerequisiteItem
+          key={i}
+          clause={subClause}
+          operator={operator}
+          isLast={i === subClauses.length - 1}
         />
-      )}
-      {isEmpty && (
-        <div style={reqStyle}>No prerequisites. You&apos;re good to go!</div>
-      )}
-      {expanded &&
-        isHeader &&
-        subreqs &&
-        subreqs.map((reqs, i) => (
-          <div key={i} className={classes('divider-bottom', 'nested')}>
-            <Prerequisite req={reqs} isLast={i === subreqs.length - 1} />
-          </div>
-        ))}
+      ))}
+    </>
+  );
+}
+
+type PrerequisiteItemProps = {
+  clause: PrerequisiteClause;
+  operator: PrerequisiteOperator;
+  isLast: boolean;
+};
+
+/**
+ * Renders a single "item" -- a div with the completely flattened text
+ * representation of the prereq subtree passed in as `clause` (whether
+ * that's a single prereq course or a sprawling sub-tree with many branches).
+ * Includes the ability to display a higher-level operator between different
+ * `PrerequisiteItem`'s as long as `isLast` is false, which is used by
+ * `PrerequisiteClauseDisplay` when it needs to render a prerequisite set.
+ `
+ */
+function PrerequisiteItem({
+  clause,
+  operator,
+  isLast,
+}: PrerequisiteItemProps): React.ReactElement {
+  return (
+    <div className={classes('divider-bottom')} style={BASE_ITEM_STYLE}>
+      {serializePrereqs(clause)} {!isLast && <strong>{operator}</strong>}
     </div>
+  );
+}
+
+/**
+ * Replacement prerequisite "item"-like component that simply contains
+ * a notification to the user that the course has no prereqs.
+ */
+function PrerequisiteEmpty(): React.ReactElement {
+  return (
+    <div style={BASE_ITEM_STYLE}>No prerequisites. You&apos;re good to go!</div>
   );
 }

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -149,7 +149,7 @@ export function humanizeArrayReact<T>(
   );
 }
 
-export const decryptReqs = (
+export const serializePrereqs = (
   reqs: PrerequisiteClause,
   openPar = false,
   closePar = false
@@ -169,12 +169,13 @@ export const decryptReqs = (
   } else if (reqs[0] === 'and') {
     const [, ...subClauses] = reqs;
     subClauses.forEach((req, i) => {
-      string += decryptReqs(req, i === 0, last(i)) + (last(i) ? '' : ' and ');
+      string +=
+        serializePrereqs(req, i === 0, last(i)) + (last(i) ? '' : ' and ');
     });
   } else if (reqs[0] === 'or') {
     const [, ...subClauses] = reqs;
     subClauses.forEach((req, i) => {
-      string += decryptReqs(req) + (last(i) ? '' : ' or ');
+      string += serializePrereqs(req) + (last(i) ? '' : ' or ');
     });
   }
 


### PR DESCRIPTION
### Summary

This PR splits the existing `<Prerequisite>` component out into its individual variants to better ensure that props are passed in with the right combination/types and make the components easier to read. Additionally, this PR attempts to introduce a couple additional heuristics to skip displaying certain components of the prerequisites display if they aren't relevant (i.e. not displaying "Option 1" if the clause is an AND set or if it is an OR set with only 1 option).

### Test/rollout plan

This PR should be fairly safe, since it utilizes the types from the crawler to handle all cases when rendering the prereq trees. Additionally, I have tested it locally and it seems to work as expected.

#### Safe to rollback?

Yes
