### PR TITLE
Attach fields as structured context to sentry events; be more careful in sent context

### DIFF
--- a/src/beans/Course.ts
+++ b/src/beans/Course.ts
@@ -191,7 +191,12 @@ export default class Course {
       // Extract the course-wide average GPA
       const rawAverageGpa = responseData.header[0].avg_gpa;
       if (typeof rawAverageGpa !== 'number')
-        throw new Error(`data at ".header[0].avg_gpa" was not a number`);
+        throw new ErrorWithFields({
+          message: `data at ".header[0].avg_gpa" was not a number`,
+          fields: {
+            actual: rawAverageGpa,
+          },
+        });
       gpaMap.averageGpa = rawAverageGpa;
 
       // Extract the GPA for each instructor
@@ -199,14 +204,24 @@ export default class Course {
         // Extract the instructor's name
         const rawInstructor = instructorData.instructor_name;
         if (typeof rawInstructor !== 'string')
-          throw new Error(
-            `data at ".raw[${i}].instructor_name" was not a string`
-          );
+          throw new ErrorWithFields({
+            message: `data at ".raw[idx].instructor_name" was not a string`,
+            fields: {
+              idx: i,
+              actual: rawInstructor,
+            },
+          });
 
         // Extract the instructor's GPA
         const instructorGpa = instructorData.GPA;
         if (typeof instructorGpa !== 'number')
-          throw new Error(`data at ".raw[${i}].GPA" was not a number`);
+          throw new ErrorWithFields({
+            message: `data at ".raw[idx].GPA" was not a number`,
+            fields: {
+              idx: i,
+              actual: instructorGpa,
+            },
+          });
 
         // Normalize the instructor name from "LN, FN" to "FN LN"
         let instructor = rawInstructor;
@@ -229,7 +244,6 @@ export default class Course {
             baseId: this.id,
             cleanedId: id,
             url,
-            responseData,
           },
         })
       );

--- a/src/log.ts
+++ b/src/log.ts
@@ -82,6 +82,13 @@ export function softError(error: ErrorWithFields): void {
 
   // Report the error to Sentry if in production
   if (process.env.NODE_ENV === 'production') {
-    Sentry.captureException(error, error.getAllFields());
+    const fields = error.getAllFields();
+    const { type, ...rest } = fields;
+    Sentry.captureException(error, {
+      contexts: {
+        // https://docs.sentry.io/platforms/ruby/enriching-events/context/#structured-context
+        fields: { ...rest, __do_not_use_type_in_sentry_it_is_special: type },
+      },
+    });
   }
 }


### PR DESCRIPTION
### Summary

The main change is to wrap the fields in `{ context: { fields } }` when passing them in to `Sentry.captureException(...)`, which includes them as [structured context](https://docs.sentry.io/platforms/ruby/enriching-events/context/#structured-context). Additionally, this PR makes some fields more specific with max context size in mind.

### Motivation

Tries to get some additional context on Sentry errors