### PR TITLE
Handle null case in course critique API

### DIFF
--- a/src/beans/Course.ts
+++ b/src/beans/Course.ts
@@ -190,6 +190,8 @@ export default class Course {
 
       // Extract the course-wide average GPA
       const rawAverageGpa = responseData.header[0].avg_gpa;
+      // If the field is null, then the course has no GPA information
+      if (rawAverageGpa === null) return {};
       if (typeof rawAverageGpa !== 'number')
         throw new ErrorWithFields({
           message: `data at ".header[0].avg_gpa" was not a number`,
@@ -259,17 +261,17 @@ export default class Course {
 interface CourseDetailsAPIResponse {
   header: [
     {
-      course_name: string | unknown;
-      description: string | unknown;
-      credits: number | unknown;
-      avg_gpa: number | unknown;
-      avg_a: number | unknown;
-      avg_b: number | unknown;
-      avg_c: number | unknown;
-      avg_d: number | unknown;
-      avg_f: number | unknown;
-      avg_w: number | unknown;
-      full_name: string | unknown;
+      course_name: string | null | unknown;
+      description: string | null | unknown;
+      credits: number | null | unknown;
+      avg_gpa: number | null | unknown;
+      avg_a: number | null | unknown;
+      avg_b: number | null | unknown;
+      avg_c: number | null | unknown;
+      avg_d: number | null | unknown;
+      avg_f: number | null | unknown;
+      avg_w: number | null | unknown;
+      full_name: string | null | unknown;
     }
   ];
   raw: Array<{

--- a/src/log.ts
+++ b/src/log.ts
@@ -82,12 +82,16 @@ export function softError(error: ErrorWithFields): void {
 
   // Report the error to Sentry if in production
   if (process.env.NODE_ENV === 'production') {
-    const fields = error.getAllFields();
-    const { type, ...rest } = fields;
+    let fields = error.getAllFields();
+    if (Object.keys(fields).includes('type')) {
+      const { type, ...rest } = fields;
+      fields = { __do_not_use_type_in_sentry_it_is_special: type, ...rest };
+    }
+
     Sentry.captureException(error, {
       contexts: {
         // https://docs.sentry.io/platforms/ruby/enriching-events/context/#structured-context
-        fields: { ...rest, __do_not_use_type_in_sentry_it_is_special: type },
+        fields,
       },
     });
   }


### PR DESCRIPTION
### Summary

This PR handles the case where certain courses (such as [CS 1100](https://c4citk6s9k.execute-api.us-east-1.amazonaws.com/test/data/course?courseID=CS%201100)) return `null` in the `header` field.

Also, this PR fixes a bug with the sentry field handling where it always includes the field `__do_not_use_type_in_sentry_it_is_special` even when it's not needed.
