### PR TITLE
Sort courses by their start time in <Map>

### DIFF
--- a/src/components/MapView/index.tsx
+++ b/src/components/MapView/index.tsx
@@ -12,9 +12,6 @@ import './stylesheet.scss';
 export type MapLocation = {
   section: string;
   id: string;
-  title: string;
-  days: string[];
-  time: string;
   coords: Location | null;
 };
 
@@ -65,13 +62,13 @@ export default function MapView({
           ([coords, coordLocations], i) => (
             <Marker key={i} latitude={coords.lat} longitude={coords.long}>
               <FontAwesomeIcon icon={faMapPin} className="pin-icon" />
-              <p className="pin-text">
+              <div className="pin-text">
                 {coordLocations.map((coordLocation) => (
                   <div key={coordLocation.id + coordLocation.section}>
                     {coordLocation.id} {coordLocation.section}
                   </div>
                 ))}
-              </p>
+              </div>
             </Marker>
           )
         )}


### PR DESCRIPTION
### Summary

This PR sorts courses by the start time of their first meeting when constructing the course data map inside of `<Map>`. This affects both `<MapView>` and `<DaySelection>`. Additionally, in order to coalesce common behavior, this PR also makes `<Map>` construct a data structure with enough information for both `<MapView>` and `<DaySelection>` instead of doing each separately.

Finally, this PR also includes a minor change to `<MapView>` that fixes a DOM nesting issue with a `div` element being a descendant of a `p` element.

### Motivation

Fixes #45

### Rollout plan

This should be safe for CI to deploy, and shouldn't break any existing behavior.

This PR is safe to rollback.
