### PR TITLE
Add scrolling to <DaySelection>, minor style tweaks

### DIFF
--- a/src/components/DaySelection/stylesheet.scss
+++ b/src/components/DaySelection/stylesheet.scss
@@ -2,6 +2,8 @@
 
 .date-container {
   width: 320px;
+  overflow-y: auto;
+  overflow-x: hidden;
 
   @media (max-width: 900px) {
     width: 220px;
@@ -27,13 +29,19 @@
         display: flex;
         flex-direction: column;
         align-items: stretch;
-        padding: 8px 8px 4px 8px;
+        padding: 8px;
+
         .course-id {
           font-weight: bold;
         }
+
         .course-row {
-          padding: 4px;
+          padding: 0 4px;
           display: flex;
+        }
+
+        & > :not(:last-child) {
+          margin-bottom: 4px;
         }
       }
     }

--- a/src/components/Map/stylesheet.scss
+++ b/src/components/Map/stylesheet.scss
@@ -1,6 +1,8 @@
 .map-content {
   display: flex;
-  height: 100vh;
+  flex-grow: 1;
+  overflow: hidden;
+  flex: 1;
 
   @media (max-width: 500px) {
     flex-direction: column;

--- a/src/components/MapView/stylesheet.scss
+++ b/src/components/MapView/stylesheet.scss
@@ -1,6 +1,5 @@
 .mapbox {
-  // subtract header height
-  height: calc(100% - 64px);
+  height: 100%;
   width: 100%;
 
   .pin-text {


### PR DESCRIPTION
### Summary

This PR mainly fixes scrolling in `<DaySelection>`, which before would just cut off if there were too many courses to display on the same screen at the same time. Towards these ends, this PR also includes changes to the greater map styles that control the tab's content root's height.

In addition, this PR changes the way padding is determined between classes inside `<DaySelection>` to be a bit cleaner; the only visual change is that there is now a bit of padding between the course ID and the course rows (which probably should have been there before).

### Motivation

Ensuring that courses in `<DaySelection>` can be viewed even when there is a long list. Also, minor fixes to styles to improve spacing.

### Rollout plan

This should be safe for CI to deploy, and shouldn't break any existing behavior.

This PR is safe to rollback.

