### PR TITLE
Move feedback button/form slightly, ensure button is opaque on hover

### DIFF
--- a/src/components/Feedback/index.tsx
+++ b/src/components/Feedback/index.tsx
@@ -32,12 +32,14 @@ export default function Feedback(): React.ReactElement {
   return (
     <div>
       {!expanded && (
-        <Button
-          className="FeedbackButton"
-          onClick={(): void => setExpanded(true)}
-        >
-          <FontAwesomeIcon icon={faCommentAlt} size="2x" />
-        </Button>
+        <div className="FeedbackButtonWrapper">
+          <Button
+            className="FeedbackButton"
+            onClick={(): void => setExpanded(true)}
+          >
+            <FontAwesomeIcon icon={faCommentAlt} size="2x" />
+          </Button>
+        </div>
       )}
       {expanded && (
         <div>

--- a/src/components/Feedback/stylesheet.scss
+++ b/src/components/Feedback/stylesheet.scss
@@ -1,8 +1,16 @@
-.FeedbackButton {
-  position: absolute;
-  bottom: 40px;
-  right: 24px;
+// Create a wrapper with a solid background color
+// so that hover states properly lighten the button
+.FeedbackButtonWrapper {
   background-color: var(--theme-card-bg);
+  border-radius: 5px;
+  position: absolute;
+  bottom: 24px;
+  right: 24px;
+  width: 60px;
+  height: 60px;
+}
+
+.FeedbackButton {
   width: 60px;
   height: 60px;
   border-radius: 5px;
@@ -11,7 +19,7 @@
 
 .FeedbackForm {
   position: absolute;
-  bottom: 40px;
+  bottom: 24px;
   right: 24px;
   background-color: var(--theme-card-bg);
   width: 300px;


### PR DESCRIPTION
### Summary

This PR includes two minor changes:
- moving the feedback button/form down slightly so that it is equidistant from the right and bottom edge. This makes it overlap with the attribution div instead of being flush against it.
- fixing the button becoming translucent upon hover. This was due to an interaction with the styles on `<Button>`, so now it has a background div that is always opaque.

### Motivation

Fixing visuals in edge cases

### Rollout plan

This should be safe for CI to deploy, and shouldn't break any existing behavior.

This PR is safe to rollback.
