### PR TITLE
Add sentry release as step in GitHub Actions CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,7 @@ jobs:
         run: CI=false yarn build
         env:
           REACT_APP_MAPBOX_TOKEN: ${{ secrets.REACT_APP_MAPBOX_TOKEN }}
+          REACT_SENTRY_VERSION: ${{ github.sha }}
 
       - name: Create Sentry release
         uses: getsentry/action-release@v1
@@ -30,6 +31,7 @@ jobs:
         with:
           environment: production
           sourcemaps: 'build/static/js'
+          version: ${{ github.sha }}
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,16 @@ jobs:
         env:
           REACT_APP_MAPBOX_TOKEN: ${{ secrets.REACT_APP_MAPBOX_TOKEN }}
 
+      - name: Create Sentry release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        with:
+          environment: production
+          sourcemaps: 'build/static/js'
+
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,6 +18,10 @@ if (process.env.NODE_ENV === 'production') {
     integrations: [new Integrations.BrowserTracing()],
     tracesSampleRate: 0.2,
     ignoreErrors: ['ResizeObserver loop limit exceeded'],
+    // TypeScript wants this to use square-brackets
+    // since it's an index signature
+    // eslint-disable-next-line dot-notation
+    release: process.env['REACT_SENTRY_VERSION'],
   });
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,12 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    // Configure sourcemaps for Sentry
+    // https://docs.sentry.io/platforms/javascript/guides/react/sourcemaps/generating/#typescript
+    "sourceMap": true,
+    "inlineSources": true,
+    "sourceRoot": "/"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
### Summary

Adds the [sentry-release](https://github.com/marketplace/actions/sentry-release) GitHub Actions action to the deploy workflow, creating a Sentry release complete with [source maps](https://docs.sentry.io/platforms/javascript/guides/react/sourcemaps/).

### Motivation

#51 broke Sentry's sourcemaps since TypeScript wasn't configured to properly generate sourcemaps. This PR fixes that in addition to explicitly creating a new Sentry release for each deployment.
