### PR TITLE
Include all history when checking out in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           persist-credentials: false
+          # Fetch all history for Sentry to properly create the release
+          fetch-depth: 0
 
       - name: Install
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
### Summary

Includes all history when fetching the repo during CI (using the [fetch-depth](git push --set-upstream origin jazevedo620/fix-github-action) option).

### Motivation

Fix failing actions: https://github.com/gt-scheduler/website/runs/3516610447?check_suite_focus=true