### PR TITLE
Fix lint conflict with dot-notation, remove lint ignores

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -74,6 +74,10 @@
     "jsx-a11y/href-no-hash": "off",
     "jsx-a11y/click-events-have-key-events": "off",
     "jsx-a11y/no-static-element-interactions": "off",
+    // Disable the normal `dot-notation` in favor of the one in `@typescript-eslint`.
+    // From https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/dot-notation.md
+    "dot-notation": "off",
+    "@typescript-eslint/dot-notation": ["error"],
     // Disable the normal `no-use-before-define` in favor of the one in `@typescript-eslint`.
     // From https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-use-before-define.md#how-to-use
     "no-use-before-define": "off",

--- a/src/components/MapView/index.tsx
+++ b/src/components/MapView/index.tsx
@@ -48,9 +48,6 @@ export default function MapView({
         width="100%"
         viewState={viewState}
         mapStyle="mapbox://styles/mapbox/outdoors-v9"
-        // TypeScript wants this to use square-brackets since it's an index
-        // signature
-        // eslint-disable-next-line dot-notation
         mapboxApiAccessToken={process.env['REACT_APP_MAPBOX_TOKEN'] ?? ''}
         onViewStateChange={({
           viewState: newViewState,

--- a/src/external.d.ts
+++ b/src/external.d.ts
@@ -21,8 +21,7 @@ declare module '@sweetalert/with-react' {
     getState?(): SwalState;
     setActionValue?(opts: string | ActionOptions): void;
     stopLoading?(): void;
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    setDefaults?(opts: object): void;
+    setDefaults?(opts: Record<string, unknown>): void;
   }
 
   declare const swal: SweetAlert;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,9 +18,6 @@ if (process.env.NODE_ENV === 'production') {
     integrations: [new Integrations.BrowserTracing()],
     tracesSampleRate: 0.2,
     ignoreErrors: ['ResizeObserver loop limit exceeded'],
-    // TypeScript wants this to use square-brackets
-    // since it's an index signature
-    // eslint-disable-next-line dot-notation
     release: process.env['REACT_SENTRY_VERSION'],
   });
 }


### PR DESCRIPTION
### Summary

Minor changes to lint rules in order to fix the conflict where ESLint would dislike the use of `obj['key']` when it could be written as `obj.key` (due to [dot-notation](https://eslint.org/docs/rules/dot-notation)) but TypeScript required it to be `obj['key']` due to [noPropertyAccessFromIndexSignature](https://www.typescriptlang.org/tsconfig#noPropertyAccessFromIndexSignature). This is fixed by using the [`@typescript-eslint` version](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/dot-notation.md) of the `dot-notation` rule.

This PR also removes redundant lint ignores in order to trim the number of them that exist.

### Motivation

Code style housekeeping.
