### PR TITLE
Make ErrorWithFields more useful in Sentry, fix Sentry release injection

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,10 +19,11 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Build
-        run: CI=false yarn build
+        run: yarn build
         env:
+          CI: "true"
           REACT_APP_MAPBOX_TOKEN: ${{ secrets.REACT_APP_MAPBOX_TOKEN }}
-          REACT_SENTRY_VERSION: ${{ github.sha }}
+          REACT_APP_SENTRY_VERSION: ${{ github.sha }}
 
       - name: Create Sentry release
         uses: getsentry/action-release@v1

--- a/src/beans/Course.ts
+++ b/src/beans/Course.ts
@@ -7,7 +7,12 @@ import {
   CrawlerPrerequisites,
   Period,
 } from '../types';
-import { hasConflictBetween, isLab, isLecture } from '../utils';
+import {
+  hasConflictBetween,
+  isLab,
+  isLecture,
+  isAxiosNetworkError,
+} from '../utils';
 import { ErrorWithFields, softError } from '../log';
 
 interface SectionGroupMeeting {
@@ -168,17 +173,21 @@ export default class Course {
     try {
       responseData = (await axios.get<CourseDetailsAPIResponse>(url)).data;
     } catch (err) {
-      softError(
-        new ErrorWithFields({
-          message: 'fetching course details from Course Critique API',
-          source: err,
-          fields: {
-            baseId: this.id,
-            cleanedId: id,
-            url,
-          },
-        })
-      );
+      // Ignore network errors
+      if (!isAxiosNetworkError(err)) {
+        softError(
+          new ErrorWithFields({
+            message: 'error fetching course details from Course Critique API',
+            source: err,
+            fields: {
+              baseId: this.id,
+              cleanedId: id,
+              url,
+            },
+          })
+        );
+      }
+
       return {};
     }
 
@@ -240,7 +249,8 @@ export default class Course {
     } catch (err) {
       softError(
         new ErrorWithFields({
-          message: 'extracting course GPA from Course Critique API response',
+          message:
+            'error extracting course GPA from Course Critique API response',
           source: err,
           fields: {
             baseId: this.id,

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -4,7 +4,7 @@ import swal from '@sweetalert/with-react';
 import * as Sentry from '@sentry/react';
 import Cookies from 'js-cookie';
 
-import { classes } from '../../utils';
+import { classes, isAxiosNetworkError } from '../../utils';
 import { Header, Scheduler, Map, NavDrawer, NavMenu, Attribution } from '..';
 import Feedback from '../Feedback';
 import { Oscar } from '../../beans';
@@ -145,16 +145,20 @@ export default function App(): React.ReactElement {
           setOscar(newOscar);
         })
         .catch((err) => {
-          softError(
-            new ErrorWithFields({
-              message: 'error fetching crawler data',
-              source: err,
-              fields: {
-                term,
-                url,
-              },
-            })
-          );
+          // TODO(jazevedo620) 09-05-2021: present this as a hard error to user
+          // Ignore network errors
+          if (!isAxiosNetworkError(err)) {
+            softError(
+              new ErrorWithFields({
+                message: 'error fetching crawler data',
+                source: err,
+                fields: {
+                  term,
+                  url,
+                },
+              })
+            );
+          }
         });
     }
   }, [term]);
@@ -175,15 +179,19 @@ export default function App(): React.ReactElement {
         setTerms(newTerms);
       })
       .catch((err) => {
-        softError(
-          new ErrorWithFields({
-            message: 'error fetching list of terms',
-            source: err,
-            fields: {
-              url,
-            },
-          })
-        );
+        // TODO(jazevedo620) 09-05-2021: present this as a hard error to user
+        // Ignore network errors
+        if (!isAxiosNetworkError(err)) {
+          softError(
+            new ErrorWithFields({
+              message: 'error fetching list of terms',
+              source: err,
+              fields: {
+                url,
+              },
+            })
+          );
+        }
       });
   }, [setTerms]);
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,9 +16,9 @@ if (process.env.NODE_ENV === 'production') {
     dsn:
       'https://8955ef982197469e97c7644a8c090db1@o552970.ingest.sentry.io/5679614',
     integrations: [new Integrations.BrowserTracing()],
-    tracesSampleRate: 0.2,
+    tracesSampleRate: 1.0,
     ignoreErrors: ['ResizeObserver loop limit exceeded'],
-    release: process.env['REACT_SENTRY_VERSION'],
+    release: process.env['REACT_APP_SENTRY_VERSION'],
   });
 }
 

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -181,3 +181,12 @@ export const serializePrereqs = (
 
   return string;
 };
+
+// Determines whether an error is an axios network error,
+// which is used when determining whether to send it to Sentry
+// (since we can't do anything about a client-side NetworkError)--
+// it's either an error in the user's network
+// or downtime in a third-party service.
+export const isAxiosNetworkError = (err: unknown): boolean => {
+  return err instanceof Error && err.message.includes('Network Error');
+};


### PR DESCRIPTION
### Summary

This PR includes a few changes to `ErrorWithFields` that makes it more useful when seeing errors in Sentry, such as ensuring that the stack trace is the inner-most error's stack trace and fingerprinting by the top-level message.

It also fixes the injection of the Sentry release (which uses the Git SHA) when building in CI, which previously wasn't working.

Finally, it introduces a new utility, `isAxiosNetworkError`, which is used to ignore network errors when reporting errors to Sentry (in order to cut down on noise for non-actionable errors).

P.S. It bumps the `tracesSampleRate` Sentry option from 0.2 to 1.0 for now; we'll keep an eye on billing to ensure that this is okay.

### Motivation

- Cut down on noise in Sentry
- Make errors more useful
- Fix release injection so that information is available in Sentry
