### PR TITLE
Update lint rules to add rules of hooks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,7 @@
     "airbnb",
     "plugin:prettier/recommended",
     "prettier/react",
+    "plugin:react-hooks/recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:@typescript-eslint/recommended-requiring-type-checking"
   ],
@@ -59,6 +60,8 @@
         "ignoreRegExpLiterals": true
       }
     ],
+    "react/require-default-props": "off",
+    "no-await-in-loop": "off",
     "camelcase": "off",
     "import/no-cycle": "off",
     "class-methods-use-this": "off",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.20.6",
-    "eslint-plugin-react-hooks": "^4.1.2",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "fx": "^20.0.0",
     "gh-pages": "^2.2.0",
     "husky": "^4.3.0",

--- a/src/hooks/useJsonCookie.ts
+++ b/src/hooks/useJsonCookie.ts
@@ -30,7 +30,7 @@ export default function useJsonCookie<T extends Record<string, unknown>>(
       }
     }
     return defaultValue;
-  }, [rawValue, defaultValue]);
+  }, [key, rawValue, defaultValue]);
 
   const patchValue = useCallback(
     (patch) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5548,7 +5548,7 @@ eslint-plugin-prettier@^3.1.4:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-plugin-react-hooks@^4.1.2, eslint-plugin-react-hooks@^4.2.0:
+eslint-plugin-react-hooks@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"
   integrity sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==


### PR DESCRIPTION
### Summary

This PR enables the rules of hooks lint rules (and the other React-related-lint rules in the [`eslint-plugin-react-hooks`](https://www.npmjs.com/package/eslint-plugin-react-hooks) package. It also contains a couple minor tweaks to existing lint rules to reduce noise.

### Motivation

General code health, lower noise when developing.
