### PR TITLE
Separate InformationModal; enable dark mode on modals

### DIFF
--- a/src/components/App/stylesheet.scss
+++ b/src/components/App/stylesheet.scss
@@ -43,19 +43,19 @@
   }
 }
 
-.App.dark {
+body.dark .App {
   background-color: $theme-dark-background;
   color: $theme-dark-foreground;
   --theme-bg: #{$theme-dark-background};
-  --theme-card-bg: #434343;
+  --theme-card-bg: #{$theme-dark-card-background};
   --dark-overlay: rgba(0, 0, 0, 0.2);
 }
 
-.App.light {
+body.light .App {
   background-color: $theme-light-background;
   color: $theme-light-foreground;
   --theme-bg: #{$theme-light-background};
-  --theme-card-bg: #e5e5e5;
+  --theme-card-bg: #{$theme-light-card-background};
   --dark-overlay: rgba(0, 0, 0, 0.1);
 }
 
@@ -87,38 +87,4 @@
       }
     }
   }
-}
-
-.swal-overlay {
-  background-color: #00000099;
-}
-
-.swal-modal {
-  border-radius: 10px;
-  padding: 25px 10px;
-
-  h1 { color: #444444; font-weight: 800; }
-  p  { color: #555555; text-align: left; }
-  a {
-    &:hover { color: #ffaa5a; }
-    transition: all 0.33s ease;
-    color: #f37f6a;
-    font-weight: 700;
-  }
-}
-
-.swal-button {
-  &:hover { background-color: #ffaa5a !important; }
-  box-shadow: 0px 0px 20px #00000033;
-  transition: all 0.33s ease;
-  background-color: #f37f6a;
-  border-radius: 15px;
-  margin-top: 0.67em;
-  padding: 10px 60px;
-  font-size: 12px;
-}
-
-.swal-footer {
-  padding: 0 20px;
-  text-align: center;
 }

--- a/src/components/InformationModal/index.tsx
+++ b/src/components/InformationModal/index.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect } from 'react';
+import Cookies from 'js-cookie';
+import swal from '@sweetalert/with-react';
+
+import { softError, ErrorWithFields } from '../../log';
+
+// Key to mark when a user has already been shown the information modal.
+// Update this when updating the contents of the modal.
+// In the future, prefix all keys with `YYYY-MM-DD-`
+// to ensure that they remain globally unique.
+const MODAL_COOKIE_KEY = 'visited-merge-notice';
+
+/**
+ * Inner content of the information modal.
+ * Change this to update the announcement that is shown when visiting the site.
+ * Additionally, make sure to change `MODAL_COOKIE_KEY` with another unique
+ * value that has never been used before.
+ */
+export function InformationModalContent(): React.ReactElement {
+  return (
+    <div>
+      <img
+        style={{ width: '175px' }}
+        alt="GT Scheduler Logo"
+        src="/mascot.png"
+      />
+      <h1>GT Scheduler</h1>
+      <p>
+        Hey there, yellow jackets!{' '}
+        <a href="https://github.com/gt-scheduler">GT Scheduler</a> is a new
+        collaboration between <a href="https://bitsofgood.org/">Bits of Good</a>{' '}
+        and <a href="https://jasonpark.me/">Jason (Jinseo) Park</a> aimed at
+        making class registration easier for everybody! Now, you can access
+        course prerequisites, instructor GPAs, live seating information, and
+        more all in one location.
+      </p>
+      <p>
+        If you enjoy our work and are interested in contributing, feel free to{' '}
+        <a href="https://github.com/gt-scheduler/website/pulls">
+          open a pull request
+        </a>{' '}
+        with your improvements. Thank you and enjoy!
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Hook to show the information modal upon the user's first visit to the site
+ * when they haven't seen this version of the information modal before.
+ */
+export function useInformationModal(): void {
+  useEffect(() => {
+    if (!Cookies.get(MODAL_COOKIE_KEY)) {
+      swal({
+        button: 'Got It!',
+        content: <InformationModalContent />,
+      }).catch((err) => {
+        softError(
+          new ErrorWithFields({
+            message: 'error with swal call',
+            source: err,
+            fields: {
+              cookieKey: MODAL_COOKIE_KEY,
+            },
+          })
+        );
+      });
+
+      Cookies.set(MODAL_COOKIE_KEY, 'true', { expires: 365 });
+    }
+  }, []);
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export { default as useCookie, useCookieWithDefault } from './useCookie';
 export { default as useJsonCookie } from './useJsonCookie';
 export { default as useMobile } from './useMobile';
+export { default as useBodyClass } from './useBodyClass';

--- a/src/hooks/useBodyClass.ts
+++ b/src/hooks/useBodyClass.ts
@@ -1,0 +1,23 @@
+import { useLayoutEffect } from 'react';
+
+/**
+ * Adds the given class(es) to the HTML `body` element
+ * when this hook runs.
+ */
+export default function useBodyClass(className: string | string[]): void {
+  useLayoutEffect(() => {
+    if (typeof className === 'string') {
+      document.body.classList.add(className);
+    } else {
+      document.body.classList.add(...className);
+    }
+
+    return (): void => {
+      if (typeof className === 'string') {
+        document.body.classList.remove(className);
+      } else {
+        document.body.classList.remove(...className);
+      }
+    };
+  }, [className]);
+}

--- a/src/stylesheet.scss
+++ b/src/stylesheet.scss
@@ -82,3 +82,63 @@ select {
   @include content($theme-dark-foreground, black);
 }
 
+// swal modal styles:
+
+.swal-overlay {
+  background-color: #00000099;
+}
+
+.swal-modal {
+  border-radius: 10px;
+  padding: 25px 10px;
+
+  @include dark {
+    background-color: #{$theme-dark-card-background};
+  }
+
+  h1 {
+    color: #444444;
+    font-weight: 800;
+
+    @include dark {
+      color: #eeeeee;
+    }
+  }
+
+  p {
+    color: #555555;
+    text-align: left;
+
+    @include dark {
+      color: #dddddd;
+    }
+  }
+
+  a {
+    &:hover {
+      color: #ffaa5a;
+    }
+    transition: all 0.33s ease;
+    color: #f37f6a;
+    font-weight: 700;
+  }
+}
+
+.swal-button {
+  &:hover {
+    background-color: #e2944b !important;
+  }
+
+  box-shadow: 0px 0px 20px #00000033;
+  transition: all 0.33s ease;
+  background-color: #d36855;
+  border-radius: 15px;
+  margin-top: 0.67em;
+  padding: 10px 60px;
+  font-size: 12px;
+}
+
+.swal-footer {
+  padding: 0 20px;
+  text-align: center;
+}

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -5,9 +5,11 @@ $day-height: 40px;
 $header-height: 64px;
 
 $color-neutral: #808080;
-$color-border: rgba($color-neutral, .2);
-$theme-light-background: #FFFFFF;
+$color-border: rgba($color-neutral, 0.2);
+$theme-light-background: #ffffff;
 $theme-dark-background: #333333;
+$theme-light-card-background: #e5e5e5;
+$theme-dark-card-background: #434343;
 $theme-light-foreground: $theme-dark-background;
 $theme-dark-foreground: $theme-light-background;
 $color-background-light: #f8f9fa;
@@ -17,8 +19,33 @@ $opacity-disabled: 0.38;
 $opacity-divider: 0.4;
 
 @mixin card {
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, .2), 0 1px 1px 0 rgba(0, 0, 0, .14), 0 2px 1px -1px rgba(0, 0, 0, .12);
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14),
+    0 2px 1px -1px rgba(0, 0, 0, 0.12);
   margin: 4px;
   border-radius: 4px;
   overflow: hidden;
+}
+
+@mixin light($property: null, $value: null) {
+  @if $property == null {
+    body.light & {
+      @content;
+    }
+  } @else {
+    body.light & {
+      #{$property}: $value;
+    }
+  }
+}
+
+@mixin dark($property: null, $value: null) {
+  @if $property == null {
+    body.dark & {
+      @content;
+    }
+  } @else {
+    body.dark & {
+      #{$property}: $value;
+    }
+  }
 }


### PR DESCRIPTION
### Summary

This PR separates `<InformationModal>` into its own component, as the start of larger changes to `<App>` that will eventually land with changes to the core data loading/fetching in #69. It also enables dark mode for the modal, which requires hoisting the dynamic theme CSS class (either `.light` or `.dark`) from the `div.App` element to the HTML `body` element. This is because the [swal](https://sweetalert2.github.io/) modals get appended to the body outside of the normal React hierarchy, so the existing cascades from `App.light` and `App.dark` don't work on modals.

![dark-mode-modal](https://user-images.githubusercontent.com/26242455/132422491-da0309ce-6547-4599-b62b-19278d88fc75.png)

Additionally, this PR also moves a bit of functionality out of `<App>` into a couple of smaller, private sub-components, `<ThemeLoader>` and `<AppCSSRoot>`.

### Motivation

Improve visuals by making color schemes apply to more places, and pave the way to more changes that will land in #69 and beyond.
