### PR TITLE
Add term to the fields of soft errors; simplify context values

### DIFF
--- a/src/beans/Course.ts
+++ b/src/beans/Course.ts
@@ -52,7 +52,10 @@ export default class Course {
 
   sectionGroups: Record<string, SectionGroup> | undefined;
 
+  term: string;
+
   constructor(oscar: Oscar, courseId: string, data: CrawlerCourse) {
+    this.term = oscar.term;
     const [title, sections, prereqs] = data;
 
     this.id = courseId;
@@ -64,6 +67,7 @@ export default class Course {
           id: this.id,
           subject,
           number,
+          term: this.term,
         },
       });
     }
@@ -83,6 +87,7 @@ export default class Course {
               source: err,
               fields: {
                 courseId,
+                term: this.term,
               },
             })
           );
@@ -183,6 +188,7 @@ export default class Course {
               baseId: this.id,
               cleanedId: id,
               url,
+              term: this.term,
             },
           })
         );
@@ -206,6 +212,7 @@ export default class Course {
           message: `data at ".header[0].avg_gpa" was not a number`,
           fields: {
             actual: rawAverageGpa,
+            term: this.term,
           },
         });
       gpaMap.averageGpa = rawAverageGpa;
@@ -220,6 +227,7 @@ export default class Course {
             fields: {
               idx: i,
               actual: rawInstructor,
+              term: this.term,
             },
           });
 
@@ -231,6 +239,7 @@ export default class Course {
             fields: {
               idx: i,
               actual: instructorGpa,
+              term: this.term,
             },
           });
 
@@ -256,6 +265,7 @@ export default class Course {
             baseId: this.id,
             cleanedId: id,
             url,
+            term: this.term,
           },
         })
       );

--- a/src/beans/Oscar.ts
+++ b/src/beans/Oscar.ts
@@ -39,7 +39,7 @@ export default class Oscar {
 
   sortingOptions: SortingOption[];
 
-  constructor(data: OscarConstructionDate) {
+  constructor(data: OscarConstructionDate, public term: string) {
     const { courses, caches, updatedAt, version } = data;
 
     this.periods = caches.periods.map((period, i) => {
@@ -55,6 +55,7 @@ export default class Oscar {
             fields: {
               period,
               cacheIndex: i,
+              term: this.term,
             },
           })
         );
@@ -77,6 +78,7 @@ export default class Oscar {
             fields: {
               dateRange,
               cacheIndex: i,
+              term: this.term,
             },
           })
         );
@@ -108,6 +110,7 @@ export default class Oscar {
             fields: {
               courseId,
               source,
+              term: this.term,
             },
           })
         );
@@ -264,6 +267,7 @@ export default class Oscar {
         fields: {
           sortingOptionIndex,
           actualSortingOptionsLength: this.sortingOptions.length,
+          term: this.term,
         },
       });
     }
@@ -299,17 +303,20 @@ export default class Oscar {
  * Create an empty instance of the Oscar bean
  * to use as the default context value
  */
-export const EMPTY_OSCAR = new Oscar({
-  courses: {},
-  caches: {
-    periods: [],
-    dateRanges: [],
-    scheduleTypes: [],
-    campuses: [],
-    attributes: [],
-    gradeBases: [],
-    locations: [],
+export const EMPTY_OSCAR = new Oscar(
+  {
+    courses: {},
+    caches: {
+      periods: [],
+      dateRanges: [],
+      scheduleTypes: [],
+      campuses: [],
+      attributes: [],
+      gradeBases: [],
+      locations: [],
+    },
+    updatedAt: new Date(),
+    version: 1,
   },
-  updatedAt: new Date(),
-  version: 1,
-});
+  '197008'
+);

--- a/src/beans/Section.ts
+++ b/src/beans/Section.ts
@@ -60,12 +60,15 @@ export default class Section {
   // This field is initialized after construction inside `Course.constructor`
   associatedLectures: Section[];
 
+  term: string;
+
   constructor(
     oscar: Oscar,
     course: Course,
     sectionId: string,
     data: SectionConstructionData
   ) {
+    this.term = oscar.term;
     const [
       crn,
       meetings,

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -16,7 +16,6 @@ import {
   TermContext,
   TermContextValue,
   TermsContext,
-  TermsContextValue,
   ThemeContext,
   ThemeContextValue,
 } from '../../contexts';
@@ -70,19 +69,15 @@ export default function App(): React.ReactElement {
   }, [oscar, termData]);
 
   // Memoize context values so that their references are stable
-  const termsContextValue = useMemo<TermsContextValue>(
-    () => [terms, setTerms],
-    [terms, setTerms]
-  );
   const termContextValue = useMemo<TermContextValue>(
     () => [
       // We ensure that oscar is non-null when we give this to the context
       // provider, so while this is an unsafe cast we ensure the safety
       // manually.
       { term, oscar: oscar as Oscar, ...filteredTermData },
-      { setTerm, setOscar, patchTermData },
+      { setTerm, patchTermData },
     ],
-    [term, oscar, filteredTermData, setTerm, setOscar, patchTermData]
+    [term, oscar, filteredTermData, setTerm, patchTermData]
   );
 
   // Fetch the current term's scraper information
@@ -93,7 +88,7 @@ export default function App(): React.ReactElement {
       axios
         .get(url)
         .then((res) => {
-          const newOscar = new Oscar(res.data);
+          const newOscar = new Oscar(res.data, term);
           setOscar(newOscar);
         })
         .catch((err) => {
@@ -200,7 +195,7 @@ export default function App(): React.ReactElement {
   return (
     <ThemeLoader>
       <AppCSSRoot>
-        <TermsContext.Provider value={termsContextValue}>
+        <TermsContext.Provider value={terms}>
           <TermContext.Provider value={termContextValue}>
             <Sentry.ErrorBoundary fallback={<div>An error has occurred</div>}>
               {/* On mobile, show the nav drawer + overlay */}

--- a/src/components/Course/index.tsx
+++ b/src/components/Course/index.tsx
@@ -53,6 +53,7 @@ export default function Course({
               source: err,
               fields: {
                 courseId,
+                term: course.term,
               },
             })
           );

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -44,7 +44,7 @@ export default function Header({
   tabs,
 }: HeaderProps): React.ReactElement {
   const [{ term, oscar, pinnedCrns }, { setTerm }] = useContext(TermContext);
-  const [terms] = useContext(TermsContext);
+  const terms = useContext(TermsContext);
   const [theme, setTheme] = useContext(ThemeContext);
   const captureRef = useRef<HTMLDivElement>(null);
 

--- a/src/components/Prerequisite/index.tsx
+++ b/src/components/Prerequisite/index.tsx
@@ -80,6 +80,7 @@ export default function Prerequisite({
             fields: {
               courseId: course.id,
               operator: op,
+              term: course.term,
             },
           })
         );

--- a/src/components/Section/index.tsx
+++ b/src/components/Section/index.tsx
@@ -50,7 +50,7 @@ export default function Section({
               new ErrorWithFields({
                 message: 'error while fetching seating',
                 source: err,
-                fields: { crn: section.crn },
+                fields: { crn: section.crn, term: section.term },
               })
             )
           );

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -9,22 +9,18 @@ type Setter<T> = (next: T) => void;
 export type ThemeContextValue = [Theme, Setter<Theme>];
 export const ThemeContext = React.createContext<ThemeContextValue>([
   'light',
-  (): void => {
+  (next: Theme): void => {
     throw new ErrorWithFields({
       message: 'empty ThemeContext.setTheme value being used',
+      fields: {
+        next,
+      },
     });
   },
 ]);
 
-export type TermsContextValue = [string[], Setter<string[]>];
-export const TermsContext = React.createContext<TermsContextValue>([
-  [],
-  (): void => {
-    throw new ErrorWithFields({
-      message: 'empty TermsContext.setTerms value being used',
-    });
-  },
-]);
+export type TermsContextValue = string[];
+export const TermsContext = React.createContext<TermsContextValue>([]);
 
 export type TermContextData = {
   term: string;
@@ -32,7 +28,6 @@ export type TermContextData = {
 } & TermData;
 export type TermContextSetters = {
   setTerm: Setter<string>;
-  setOscar: Setter<Oscar>;
   patchTermData: Setter<Partial<TermData>>;
 };
 export type TermContextValue = [TermContextData, TermContextSetters];
@@ -43,19 +38,20 @@ export const TermContext = React.createContext<TermContextValue>([
     ...defaultTermData,
   },
   {
-    setTerm: (): void => {
+    setTerm: (next: string): void => {
       throw new ErrorWithFields({
         message: 'empty TermContext.setTerm value being used',
+        fields: {
+          next,
+        },
       });
     },
-    setOscar: (): void => {
-      throw new ErrorWithFields({
-        message: 'empty TermContext.setOscar value being used',
-      });
-    },
-    patchTermData: (): void => {
+    patchTermData: (patch: Partial<TermData>): void => {
       throw new ErrorWithFields({
         message: 'empty TermContext.patchTermData value being used',
+        fields: {
+          patch,
+        },
       });
     },
   },
@@ -64,9 +60,12 @@ export const TermContext = React.createContext<TermContextValue>([
 export type OverlayCrnsContextValue = [string[], Setter<string[]>];
 export const OverlayCrnsContext = React.createContext<OverlayCrnsContextValue>([
   [],
-  (): void => {
+  (next: string[]): void => {
     throw new ErrorWithFields({
       message: 'empty OverlayCrnsContext.setOverlayCrns value being used',
+      fields: {
+        next,
+      },
     });
   },
 ]);


### PR DESCRIPTION
### Summary

This PR improves the fields of soft error reports (to Sentry), including the term wherever relevant (since it + a course ID/section CRN generally uniquely identifies a course/section, removing ambiguity) and the next value when a default setter is used. Finally, it simplifies some contexts to remove unused values.

### Motivation

Improve contexts in error reports, remove unused code (in preparation for #69 landing).

