### PR TITLE
Split <Header> into presentation & logic components

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,30 +1,13 @@
 import React, { useCallback, useContext, useMemo, useRef } from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import {
-  faAdjust,
-  faBars,
-  faCalendarAlt,
-  faDownload,
-  faPaste,
-} from '@fortawesome/free-solid-svg-icons';
-import { faGithub } from '@fortawesome/free-brands-svg-icons';
-import Cookies from 'js-cookie';
-import domtoimage from 'dom-to-image';
-import { saveAs } from 'file-saver';
-import ReactTooltip from 'react-tooltip';
 import copy from 'copy-to-clipboard';
 
-import { getSemesterName } from '../../utils';
-import { PNG_SCALE_FACTOR } from '../../constants';
-import ics from '../../vendor/ics';
-import { Button, Calendar, Select, Tab } from '..';
-import { useMobile } from '../../hooks';
+import { downloadShadowCalendar, exportCoursesToCalendar } from '../../utils';
+import { Calendar } from '..';
 import { TermContext, TermsContext, ThemeContext } from '../../contexts';
-import { ICS } from '../../types';
 import { ErrorWithFields, softError } from '../../log';
+import HeaderDisplay from '../HeaderDisplay';
 
 import './stylesheet.scss';
-import 'react-virtualized/styles.css';
 
 export type HeaderProps = {
   currentTab: number;
@@ -34,8 +17,9 @@ export type HeaderProps = {
 };
 
 /**
- * Renders the top header component,
- * and includes controls for top-level tab-based navigation
+ * Renders the top header component with all state/interactivity,
+ * and includes controls for top-level tab-based navigation.
+ * Acts as a wrapper around `<HeaderDisplay>` that provides all props.
  */
 export default function Header({
   currentTab,
@@ -45,14 +29,8 @@ export default function Header({
 }: HeaderProps): React.ReactElement {
   const [{ term, oscar, pinnedCrns }, { setTerm }] = useContext(TermContext);
   const terms = useContext(TermsContext);
-  const [theme, setTheme] = useContext(ThemeContext);
+  const [theme] = useContext(ThemeContext);
   const captureRef = useRef<HTMLDivElement>(null);
-
-  const handleThemeChange = useCallback(() => {
-    const newTheme = theme === 'light' ? 'dark' : 'light';
-    Cookies.set('theme', newTheme, { expires: 1460 });
-    setTheme(newTheme);
-  }, [theme, setTheme]);
 
   const totalCredits = useMemo(() => {
     return pinnedCrns.reduce((credits, crn) => {
@@ -62,187 +40,79 @@ export default function Header({
   }, [pinnedCrns, oscar]);
 
   const handleExport = useCallback(() => {
-    const cal = ics() as ICS | undefined;
-    if (cal == null) {
-      window.alert('This browser does not support calendar export');
-      return;
+    try {
+      exportCoursesToCalendar(oscar, pinnedCrns);
+    } catch (err) {
+      softError(
+        new ErrorWithFields({
+          message: 'exporting courses to calendar failed',
+          fields: {
+            pinnedCrns,
+            term: oscar.term,
+          },
+        })
+      );
     }
-
-    pinnedCrns.forEach((crn) => {
-      const section = oscar.findSection(crn);
-      if (section == null) return;
-
-      section.meetings.forEach((meeting) => {
-        if (!meeting.period || !meeting.days.length) return;
-        const { from, to } = meeting.dateRange;
-        const subject = section.course.id;
-        const description = section.course.title;
-        const location = meeting.where;
-        const begin = new Date(from.getTime());
-        while (
-          !meeting.days.includes(
-            ['-', 'M', 'T', 'W', 'R', 'F', '-'][begin.getDay()] ?? '-'
-          )
-        ) {
-          begin.setDate(begin.getDate() + 1);
-        }
-        begin.setHours(meeting.period.start / 60, meeting.period.start % 60);
-        const end = new Date(begin.getTime());
-        end.setHours(meeting.period.end / 60, meeting.period.end % 60);
-        const rrule = {
-          freq: 'WEEKLY',
-          until: to,
-          byday: meeting.days
-            .map(
-              (day) =>
-                ({ M: 'MO', T: 'TU', W: 'WE', R: 'TH', F: 'FR' }[day] ?? null)
-            )
-            .filter((day) => !!day),
-        };
-        cal.addEvent(subject, description, location, begin, end, rrule);
-      });
-    });
-    cal.download('gt-scheduler');
   }, [oscar, pinnedCrns]);
 
   const handleDownload = useCallback(() => {
     const captureElement = captureRef.current;
     if (captureElement == null) return;
-
-    const computed = window
-      .getComputedStyle(captureElement)
-      .getPropertyValue('left');
-
-    domtoimage
-      .toBlob(captureElement, {
-        width: captureElement.offsetWidth * PNG_SCALE_FACTOR,
-        height: captureElement.offsetHeight * PNG_SCALE_FACTOR,
-        style: {
-          transform: `scale(${PNG_SCALE_FACTOR})`,
-          'transform-origin': `${computed} 0px`,
-          'background-color': theme === 'light' ? '#FFFFFF' : '#333333',
-        },
-      })
-      .then((blob) => saveAs(blob, 'schedule.png'))
-      .catch((err) =>
-        softError(
-          new ErrorWithFields({
-            message:
-              'could not take screenshot of shadow calendar for schedule export',
-            source: err,
-          })
-        )
+    try {
+      downloadShadowCalendar(captureElement, theme);
+    } catch (err) {
+      softError(
+        new ErrorWithFields({
+          message: 'downloading shadow calendar as PNG failed',
+          fields: {
+            pinnedCrns,
+            theme,
+            term: oscar.term,
+          },
+        })
       );
-  }, [captureRef, theme]);
+    }
+  }, [captureRef, theme, pinnedCrns, oscar.term]);
 
-  // Obtain a ref to the copy button to only close its tooltip
-  const crnButton = useRef<HTMLDivElement>(null);
+  const handleCopyCrns = useCallback(() => {
+    try {
+      copy(pinnedCrns.join(', '));
+    } catch (err) {
+      softError(
+        new ErrorWithFields({
+          message: 'copying CRNs to clipboard failed',
+          fields: {
+            pinnedCrns,
+            term: oscar.term,
+          },
+        })
+      );
+    }
+  }, [pinnedCrns, oscar.term]);
 
-  // Re-render when the page is re-sized to become mobile/desktop
-  // (desktop is >= 1024 px wide)
-  const mobile = useMobile();
   return (
-    <div className="Header">
-      {/* Menu button, only displayed on mobile */}
-      {mobile && (
-        <Button className="nav-menu-button" onClick={onToggleMenu}>
-          <FontAwesomeIcon className="icon" fixedWidth icon={faBars} />
-        </Button>
-      )}
-
-      {/* Left-aligned logo */}
-      <Button className="logo">
-        <span className="gt">GT </span>
-        <span className="scheduler">Scheduler</span>
-      </Button>
-
-      {/* Term selector */}
-      <Select
-        onChange={setTerm}
-        value={term}
-        options={terms.map((currentTerm) => ({
-          value: currentTerm,
-          label: getSemesterName(currentTerm),
-        }))}
-        className="semester"
+    <>
+      <HeaderDisplay
+        totalCredits={totalCredits}
+        currentTab={currentTab}
+        onChangeTab={onChangeTab}
+        onToggleMenu={onToggleMenu}
+        tabs={tabs}
+        onCopyCrns={handleCopyCrns}
+        enableCopyCrns={pinnedCrns.length > 0}
+        onExportCalendar={handleExport}
+        enableExportCalendar={pinnedCrns.length > 0}
+        onDownloadCalendar={handleDownload}
+        enableDownloadCalendar={pinnedCrns.length > 0}
+        terms={terms}
+        currentTerm={term}
+        onChangeTerm={setTerm}
       />
-
-      <span className="credits">{totalCredits} Credits</span>
-
-      {/* Include middle-aligned tabs on desktop */}
-      {!mobile && (
-        <div className="tabs">
-          {tabs.map((tabLabel, tabIdx) => (
-            <Tab
-              key={tabIdx}
-              active={tabIdx === currentTab}
-              onClick={(): void => onChangeTab(tabIdx)}
-              label={tabLabel}
-            />
-          ))}
-        </div>
-      )}
-
-      {/* Action bar */}
-      <div className="menu">
-        <Button onClick={handleDownload} disabled={pinnedCrns.length === 0}>
-          <FontAwesomeIcon className="icon" fixedWidth icon={faDownload} />
-          <div className="text">Download</div>
-        </Button>
-        <Button onClick={handleExport} disabled={pinnedCrns.length === 0}>
-          <FontAwesomeIcon className="icon" fixedWidth icon={faCalendarAlt} />
-          <div className="text">Export</div>
-        </Button>
-
-        {/* Include separate button and tooltip component
-            with manually controlled closing logic */}
-        <div
-          className="menu"
-          data-tip
-          data-for="copy-crn"
-          delay-hide="1000"
-          ref={crnButton}
-        >
-          <Button disabled={pinnedCrns.length === 0}>
-            <FontAwesomeIcon className="icon" fixedWidth icon={faPaste} />
-            <div className="text">CRNs</div>
-          </Button>
-        </div>
-        {/* Only enable the tooltip logic if there are CRNS to copy */}
-        {pinnedCrns.length > 0 && (
-          <ReactTooltip
-            id="copy-crn"
-            type="dark"
-            place="bottom"
-            effect="solid"
-            event="click"
-            delayHide={1000}
-            afterShow={(): void => {
-              copy(pinnedCrns.join(', '));
-              setTimeout(
-                () => ReactTooltip.hide(crnButton.current ?? undefined),
-                1000
-              );
-            }}
-          >
-            Copied to clipboard!
-          </ReactTooltip>
-        )}
-
-        <Button onClick={handleThemeChange}>
-          <FontAwesomeIcon className="icon" fixedWidth icon={faAdjust} />
-          <div className="text">Theme</div>
-        </Button>
-        <Button href="https://github.com/gt-scheduler/website">
-          <FontAwesomeIcon className="icon" fixedWidth icon={faGithub} />
-          <div className="text">GitHub</div>
-        </Button>
-      </div>
 
       {/* Fake calendar used to capture screenshots */}
       <div className="capture-container" ref={captureRef}>
         <Calendar className="fake-calendar" capture overlayCrns={[]} />
       </div>
-    </div>
+    </>
   );
 }

--- a/src/components/Header/stylesheet.scss
+++ b/src/components/Header/stylesheet.scss
@@ -1,86 +1,12 @@
 @import '../../variables';
 
-.Header {
-  height: $header-height;
-  padding: 0 16px 0 0;
-  display: flex;
-  align-items: stretch;
-  border-bottom: 1px solid $color-border;
+.capture-container {
+  position: absolute;
+  top: 0;
+  left: 100vw;
+  background-color: inherit;
 
-  .logo {
-    font-size: 1.5em;
-    font-weight: bold;
-    white-space: pre;
-    padding: 0 16px;
-
-    .gt {
-    }
-
-    .scheduler {
-    }
+  .fake-calendar {
+    width: $calendar-width;
   }
-
-  .tabs {
-    display: flex;
-    flex-direction: row;
-    margin-left: auto;
-    margin-right: auto;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .semester {
-  }
-
-  .credits {
-    padding: 12px;
-    display: flex;
-    align-items: center;
-  }
-
-  .menu {
-    display: flex;
-    align-items: stretch;
-
-    .text {
-      margin-left: 4px;
-
-      // Make the text hidden on all buttons
-      // at sufficiently-small screen sizes
-      @media screen and (max-width: 1200px) {
-        display: none;
-      }
-    }
-  }
-}
-
-.mobile .Header {
-  padding: 0 8px;
-
-  .logo {
-    display: none;
-  }
-
-  .credits {
-    display: none;
-  }
-
-  .menu {
-    flex: 1;
-    margin-left: 0;
-
-    .Button {
-      flex: 1;
-      padding: 0;
-    }
-  }
-}
-
-.nav-menu-button {
-  // Increase the tap target size
-  margin-left: -8px;
-  padding: 0 16px;
-
-  // Increase the icon size
-  font-size: 1.7rem;
 }

--- a/src/components/HeaderDisplay/index.tsx
+++ b/src/components/HeaderDisplay/index.tsx
@@ -1,0 +1,172 @@
+import React, { useCallback, useContext, useRef } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faAdjust,
+  faBars,
+  faCalendarAlt,
+  faDownload,
+  faPaste,
+} from '@fortawesome/free-solid-svg-icons';
+import { faGithub } from '@fortawesome/free-brands-svg-icons';
+import Cookies from 'js-cookie';
+import ReactTooltip from 'react-tooltip';
+
+import { getSemesterName } from '../../utils';
+import { Button, Select, Tab } from '..';
+import { useMobile } from '../../hooks';
+import { ThemeContext } from '../../contexts';
+
+import './stylesheet.scss';
+
+export type HeaderDisplayProps = {
+  totalCredits?: number | null;
+  currentTab: number;
+  onChangeTab: (newTab: number) => void;
+  onToggleMenu: () => void;
+  tabs: string[];
+  onCopyCrns?: () => void;
+  enableCopyCrns?: boolean;
+  onExportCalendar?: () => void;
+  enableExportCalendar?: boolean;
+  onDownloadCalendar?: () => void;
+  enableDownloadCalendar?: boolean;
+  terms: string[];
+  currentTerm: string;
+  onChangeTerm: (next: string) => void;
+};
+
+/**
+ * Renders the top header component as a simple display component,
+ * letting any substantive state be passed in as props.
+ * See `<Header>` for the full implementation that owns the header state.
+ * This is safe to render without `TermContext` or `TermsContext` being present.
+ */
+export default function HeaderDisplay({
+  totalCredits = null,
+  currentTab,
+  onChangeTab,
+  onToggleMenu,
+  tabs,
+  onCopyCrns = (): void => undefined,
+  enableCopyCrns = false,
+  onExportCalendar = (): void => undefined,
+  enableExportCalendar = false,
+  onDownloadCalendar = (): void => undefined,
+  enableDownloadCalendar = false,
+  terms,
+  currentTerm,
+  onChangeTerm,
+}: HeaderDisplayProps): React.ReactElement {
+  const [theme, setTheme] = useContext(ThemeContext);
+
+  const handleThemeChange = useCallback(() => {
+    const newTheme = theme === 'light' ? 'dark' : 'light';
+    Cookies.set('theme', newTheme, { expires: 1460 });
+    setTheme(newTheme);
+  }, [theme, setTheme]);
+
+  // Obtain a ref to the copy button to only close its tooltip
+  const crnButton = useRef<HTMLDivElement>(null);
+
+  // Re-render when the page is re-sized to become mobile/desktop
+  // (desktop is >= 1024 px wide)
+  const mobile = useMobile();
+  return (
+    <div className="Header">
+      {/* Menu button, only displayed on mobile */}
+      {mobile && (
+        <Button className="nav-menu-button" onClick={onToggleMenu}>
+          <FontAwesomeIcon className="icon" fixedWidth icon={faBars} />
+        </Button>
+      )}
+
+      {/* Left-aligned logo */}
+      <Button className="logo">
+        <span className="gt">GT </span>
+        <span className="scheduler">Scheduler</span>
+      </Button>
+
+      {/* Term selector */}
+      <Select
+        onChange={onChangeTerm}
+        value={currentTerm}
+        options={terms.map((term) => ({
+          value: term,
+          label: getSemesterName(term),
+        }))}
+        className="semester"
+      />
+
+      <span className="credits">{totalCredits} Credits</span>
+
+      {/* Include middle-aligned tabs on desktop */}
+      {!mobile && (
+        <div className="tabs">
+          {tabs.map((tabLabel, tabIdx) => (
+            <Tab
+              key={tabIdx}
+              active={tabIdx === currentTab}
+              onClick={(): void => onChangeTab(tabIdx)}
+              label={tabLabel}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Action bar */}
+      <div className="menu">
+        <Button onClick={onDownloadCalendar} disabled={!enableDownloadCalendar}>
+          <FontAwesomeIcon className="icon" fixedWidth icon={faDownload} />
+          <div className="text">Download</div>
+        </Button>
+        <Button onClick={onExportCalendar} disabled={!enableExportCalendar}>
+          <FontAwesomeIcon className="icon" fixedWidth icon={faCalendarAlt} />
+          <div className="text">Export</div>
+        </Button>
+
+        {/* Include separate button and tooltip component
+              with manually controlled closing logic */}
+        <div
+          className="menu"
+          data-tip
+          data-for="copy-crn"
+          delay-hide="1000"
+          ref={crnButton}
+        >
+          <Button disabled={!enableCopyCrns}>
+            <FontAwesomeIcon className="icon" fixedWidth icon={faPaste} />
+            <div className="text">CRNs</div>
+          </Button>
+        </div>
+        {enableCopyCrns && (
+          <ReactTooltip
+            id="copy-crn"
+            type="dark"
+            place="bottom"
+            effect="solid"
+            event="click"
+            delayHide={1000}
+            afterShow={(): void => {
+              onCopyCrns();
+              setTimeout(
+                () => ReactTooltip.hide(crnButton.current ?? undefined),
+                1000
+              );
+            }}
+          >
+            Copied to clipboard!
+          </ReactTooltip>
+        )}
+
+        <Button onClick={handleThemeChange}>
+          <FontAwesomeIcon className="icon" fixedWidth icon={faAdjust} />
+          <div className="text">Theme</div>
+        </Button>
+        <Button href="https://github.com/gt-scheduler/website">
+          <FontAwesomeIcon className="icon" fixedWidth icon={faGithub} />
+          <div className="text">GitHub</div>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/HeaderDisplay/stylesheet.scss
+++ b/src/components/HeaderDisplay/stylesheet.scss
@@ -1,0 +1,77 @@
+@import '../../variables';
+
+.Header {
+  height: $header-height;
+  padding: 0 16px 0 0;
+  display: flex;
+  align-items: stretch;
+  border-bottom: 1px solid $color-border;
+
+  .logo {
+    font-size: 1.5em;
+    font-weight: bold;
+    white-space: pre;
+    padding: 0 16px;
+  }
+
+  .tabs {
+    display: flex;
+    flex-direction: row;
+    margin-left: auto;
+    margin-right: auto;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .credits {
+    padding: 12px;
+    display: flex;
+    align-items: center;
+  }
+
+  .menu {
+    display: flex;
+    align-items: stretch;
+
+    .text {
+      margin-left: 4px;
+
+      // Make the text hidden on all buttons
+      // at sufficiently-small screen sizes
+      @media screen and (max-width: 1200px) {
+        display: none;
+      }
+    }
+  }
+}
+
+.mobile .Header {
+  padding: 0 8px;
+
+  .logo {
+    display: none;
+  }
+
+  .credits {
+    display: none;
+  }
+
+  .menu {
+    flex: 1;
+    margin-left: 0;
+
+    .Button {
+      flex: 1;
+      padding: 0;
+    }
+  }
+}
+
+.nav-menu-button {
+  // Increase the tap target size
+  margin-left: -8px;
+  padding: 0 16px;
+
+  // Increase the icon size
+  font-size: 1.7rem;
+}


### PR DESCRIPTION
### Summary

This PR splits `<Header>` into `<Header>` and `<HeaderDisplay>`, which handle logic and presentation of the header, respectively. In addition, it moves a couple callback functions out to `utils.tsx` to reduce the amount of code in the components and create clean modular boundaries.

### Motivation

Separating the header into the two components will allow it to have the display parts re-used for app skeletons that are rendered when data is loading/being fetched. This functionality will land in #69.
