### PR TITLE
Apply minor fixes

### DIFF
--- a/src/beans/Oscar.ts
+++ b/src/beans/Oscar.ts
@@ -315,7 +315,7 @@ export const EMPTY_OSCAR = new Oscar(
       gradeBases: [],
       locations: [],
     },
-    updatedAt: new Date(),
+    updatedAt: JSON.parse(JSON.stringify(new Date())) as string,
     version: 1,
   },
   '197008'

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -227,6 +227,7 @@ export default function App(): React.ReactElement {
     </ThemeLoader>
   );
 }
+
 // Private sub-components
 
 type ThemeLoaderProps = {

--- a/src/components/App/stylesheet.scss
+++ b/src/components/App/stylesheet.scss
@@ -30,17 +30,6 @@
       }
     }
   }
-
-  .capture-container {
-    position: absolute;
-    top: 0;
-    left: 100vw;
-    background-color: inherit;
-
-    .fake-calendar {
-      width: $calendar-width;
-    }
-  }
 }
 
 body.dark .App {

--- a/src/components/Feedback/index.tsx
+++ b/src/components/Feedback/index.tsx
@@ -30,7 +30,7 @@ export default function Feedback(): React.ReactElement {
   };
 
   return (
-    <div>
+    <>
       {!expanded && (
         <div className="FeedbackButtonWrapper">
           <Button
@@ -110,6 +110,6 @@ export default function Feedback(): React.ReactElement {
           </form>
         </div>
       )}
-    </div>
+    </>
   );
 }

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,7 +1,3 @@
-// Disable no-console for the entire file since this is the only location where
-// any logging should be performed.
-/* eslint-disable no-console */
-
 import * as Sentry from '@sentry/react';
 
 export class ErrorWithFields extends Error {
@@ -65,6 +61,7 @@ export class ErrorWithFields extends Error {
   }
 
   logToConsole(): void {
+    /* eslint-disable no-console */
     console.group(this.topMessage);
     console.error(this.getRootError());
 
@@ -74,6 +71,7 @@ export class ErrorWithFields extends Error {
     }
 
     console.groupEnd();
+    /* eslint-enable no-console */
   }
 
   getAllFields(): Record<string, unknown> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -292,7 +292,8 @@ export interface CrawlerTermData {
   /**
    * Contains the time this JSON file was retrieved
    */
-  updatedAt: Date;
+  // ! Type changed to `string` since this is what the JSON will be
+  updatedAt: string;
   /**
    * Version number for the term data
    */


### PR DESCRIPTION
### Summary

This PR applies a few minor fixes:
- Fixes the type of `CrawlerTermData.updatedAt` to be `string`, which is what the JSON contains from the crawler (the reason it wasn't always `string` is because the crawler generates a `Date` in that position, but those get serialized to strings)
- Adds an extra newline to fix style mistake in `<App>`
- Remove duplicate SCSS code in the stylesheet for `<App>`
- Make `<Feedback>` use a fragment instead of a redundant div as its outermost JSX element
- Reduce the scope of an `eslint-disable` line in `log.ts` to just apply to a single function

### Motivation

Minor fixes before #69 lands to clean up PR diff.
