### PR TITLE
Add improved dark mode to <MapView> & <DaySelection>

### DIFF
--- a/src/components/App/stylesheet.scss
+++ b/src/components/App/stylesheet.scss
@@ -10,7 +10,10 @@
   width: 100%;
   height: 100%;
   overflow: hidden;
-  transition: color .2s, background-color .2s;
+
+  // Include theme switch transition
+  transition-duration: $theme-switch-transition-duration;
+  transition-property: color, background-color;
 
   .main {
     overflow: hidden;

--- a/src/components/DaySelection/index.tsx
+++ b/src/components/DaySelection/index.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { faAngleDown, faAngleUp } from '@fortawesome/free-solid-svg-icons';
 
 import { ActionRow } from '..';
 import { classes, getContentClassName } from '../../utils';
 import { Period } from '../../types';
+import { ThemeContext } from '../../contexts';
 
 import './stylesheet.scss';
 
@@ -35,12 +36,26 @@ export type DaySelectionProps = {
   setActiveDay: (next: Day | '') => void;
 };
 
+const LIGHT_COLOR_PALETTE = [
+  '#FCB9AA',
+  '#FFDBCC',
+  '#ECEAE4',
+  '#A2E1DB',
+  '#55CBCD',
+];
+const DARK_COLOR_PALETTE = [
+  '#5e3931',
+  '#704737',
+  '#685a30',
+  '#3c6962',
+  '#286061',
+];
+
 export default function DaySelection({
   courseDateMap,
   activeDay,
   setActiveDay,
 }: DaySelectionProps): React.ReactElement {
-  const colorPalette = ['#FCB9AA', '#FFDBCC', '#ECEAE4', '#A2E1DB', '#55CBCD'];
   const daysOfTheWeek = [
     'Monday',
     'Tuesday',
@@ -48,6 +63,11 @@ export default function DaySelection({
     'Thursday',
     'Friday',
   ];
+
+  // Switch the color palette based on the current theme.
+  const [theme] = useContext(ThemeContext);
+  const colorPalette =
+    theme === 'dark' ? DARK_COLOR_PALETTE : LIGHT_COLOR_PALETTE;
 
   const formatTime = (time: number): string => {
     if (Math.floor(time / 60) >= 12) {

--- a/src/components/DaySelection/stylesheet.scss
+++ b/src/components/DaySelection/stylesheet.scss
@@ -19,6 +19,10 @@
   .date {
     @include card;
 
+    // Include theme switch transition
+    transition-duration: $theme-switch-transition-duration;
+    transition-property: color, background-color;
+
     .day-select {
       box-shadow: 1px 1px 1px gray;
     }

--- a/src/components/Feedback/stylesheet.scss
+++ b/src/components/Feedback/stylesheet.scss
@@ -1,3 +1,5 @@
+@import '../../variables';
+
 // Create a wrapper with a solid background color
 // so that hover states properly lighten the button
 .FeedbackButtonWrapper {
@@ -8,13 +10,26 @@
   right: 24px;
   width: 60px;
   height: 60px;
+
+  // Include theme switch transition
+  transition-duration: $theme-switch-transition-duration;
+  transition-property: background-color;
+}
+
+%floating-shadow {
+  box-shadow: 4px 4px 12px rgba(0, 0, 0, 0.3);
+
+  @include dark {
+    box-shadow: 4px 4px 12px rgba(0, 0, 0, 0.3);
+  }
 }
 
 .FeedbackButton {
   width: 60px;
   height: 60px;
   border-radius: 5px;
-  box-shadow: 0.5px 1px 2px rgba(0, 0, 0, 0.4);
+
+  @extend %floating-shadow;
 }
 
 .FeedbackForm {
@@ -25,9 +40,14 @@
   width: 300px;
   min-height: 350px;
   border-radius: 5px;
-  box-shadow: 0.5px 1px 2px rgba(0, 0, 0, 0.4);
   display: flex;
   flex-direction: column;
+
+  @extend %floating-shadow;
+
+  // Include theme switch transition
+  transition-duration: $theme-switch-transition-duration;
+  transition-property: background-color;
 
   .container {
     margin: 20px;
@@ -99,6 +119,10 @@
     background-color: var(--theme-bg);
     color: currentColor;
     padding: 8px;
+
+    // Include theme switch transition
+    transition-duration: $theme-switch-transition-duration;
+    transition-property: background-color;
 
     &::placeholder {
       color: #808080;

--- a/src/components/MapView/index.tsx
+++ b/src/components/MapView/index.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import ReactMapGL, { Marker, NavigationControl } from 'react-map-gl';
 import { ViewState } from 'react-map-gl/src/mapbox/mapbox';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faMapPin } from '@fortawesome/free-solid-svg-icons';
 
 import { Location } from '../../types';
+import { ThemeContext } from '../../contexts';
 
 import 'mapbox-gl/dist/mapbox-gl.css';
 import './stylesheet.scss';
@@ -41,13 +42,24 @@ export default function MapView({
     }
   });
 
+  // Switch the map style based on the current theme.
+  // These are custom styles owned by the Mapbox account in the BitWarden.
+  // Public share links:
+  // Dark: https://api.mapbox.com/styles/v1/gt-scheduler/cktc4yzhm018w17ql65xa802o.html?fresh=true&title=copy&access_token=pk.eyJ1IjoiZ3Qtc2NoZWR1bGVyIiwiYSI6ImNrdGM0cXlqMDA0aXYyeHBma290Y2NyOTgifQ.S_A1gOu-FSQ8ywQFf2rr5A
+  // Light: https://api.mapbox.com/styles/v1/gt-scheduler/cktc4y61t018918qjynvngozg.html?fresh=true&title=copy&access_token=pk.eyJ1IjoiZ3Qtc2NoZWR1bGVyIiwiYSI6ImNrdGM0cXlqMDA0aXYyeHBma290Y2NyOTgifQ.S_A1gOu-FSQ8ywQFf2rr5A
+  const [theme] = useContext(ThemeContext);
+  const mapStyle =
+    theme === 'dark'
+      ? 'mapbox://styles/gt-scheduler/cktc4yzhm018w17ql65xa802o' // gt-scheduler-dark
+      : 'mapbox://styles/gt-scheduler/cktc4y61t018918qjynvngozg'; // gt-scheduler-light
+
   return (
     <div className="mapbox">
       <ReactMapGL
         height="100%"
         width="100%"
         viewState={viewState}
-        mapStyle="mapbox://styles/mapbox/outdoors-v9"
+        mapStyle={mapStyle}
         mapboxApiAccessToken={process.env['REACT_APP_MAPBOX_TOKEN'] ?? ''}
         onViewStateChange={({
           viewState: newViewState,

--- a/src/components/MapView/stylesheet.scss
+++ b/src/components/MapView/stylesheet.scss
@@ -1,3 +1,5 @@
+@import "../../variables";
+
 .mapbox {
   height: 100%;
   width: 100%;
@@ -11,10 +13,7 @@
     padding: 8px;
     margin: 0;
 
-    box-shadow: 0px 0px 3px #00000080;
-    background: #ffffffcc;
-    border-radius: 8px;
-    color: #333333;
+    @extend %floating-box;
   }
 
   .pin {
@@ -43,10 +42,7 @@
     font-size: 14px;
     z-index: 0;
 
-    border-radius: 8px;
-    box-shadow: 0px 0px 3px #00000080;
-    background: white;
-    color: #333333;
+    @extend %floating-box;
 
     @media (max-width: 900px) {
       margin-top: 8px;
@@ -65,5 +61,21 @@
     position: absolute;
     bottom: 30px;
     right: 10px;
+  }
+}
+
+%floating-box {
+  border-radius: 8px;
+  box-shadow: 0px 0px 3px #00000080;
+  background: white;
+  color: #333333;
+
+  // Include theme switch transition
+  transition-duration: $theme-switch-transition-duration;
+  transition-property: color, background-color;
+
+  @include dark {
+    background: #111111;
+    color: #eeeeee;
   }
 }

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -18,6 +18,8 @@ $opacity-inactive: 0.6;
 $opacity-disabled: 0.38;
 $opacity-divider: 0.4;
 
+$theme-switch-transition-duration: 0.2s;
+
 @mixin card {
   box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14),
     0 2px 1px -1px rgba(0, 0, 0, 0.12);


### PR DESCRIPTION
### Summary

This PR adds improved dark mode to the `<MapView>` and `<DaySelection>` components. For `<MapView>`, this involves using a different [Mapbox map style](https://docs.mapbox.com/mapbox-gl-js/example/custom-style-id/) depending on the theme, and while I was at it, I created two custom map styles for use with the scheduler (which place visual emphasis on buildings, foot paths, and building names and de-emphasize roads or natural features):

- [gt-scheduler-dark](https://api.mapbox.com/styles/v1/gt-scheduler/cktc4yzhm018w17ql65xa802o.html?fresh=true&title=copy&access_token=pk.eyJ1IjoiZ3Qtc2NoZWR1bGVyIiwiYSI6ImNrdGM0cXlqMDA0aXYyeHBma290Y2NyOTgifQ.S_A1gOu-FSQ8ywQFf2rr5A)
- [gt-scheduler-light](https://api.mapbox.com/styles/v1/gt-scheduler/cktc4y61t018918qjynvngozg.html?fresh=true&title=copy&access_token=pk.eyJ1IjoiZ3Qtc2NoZWR1bGVyIiwiYSI6ImNrdGM0cXlqMDA0aXYyeHBma290Y2NyOTgifQ.S_A1gOu-FSQ8ywQFf2rr5A)

These styles were made using Mapbox Studio and are owned by the gt-scheduler Mapbox account in Bitwarden.

Additionally, for the `<DaySelection>` component, I just created a new color ramp with 5 darker variations of the existing colors.

Finally, I also made elements across the app more consistently transition color/background-color when switching themes, leading to a nice visual "fade" effect.

#### Screenshots

![Screenshot_20210908_202439](https://user-images.githubusercontent.com/26242455/132602730-3aec99c1-23bf-4f17-96ee-69fddf4cbd52.png)
![Screenshot_20210908_202449](https://user-images.githubusercontent.com/26242455/132602731-363c5f4d-46c8-4ca2-a6a4-f96323a34f8f.png)

### Motivation

More consistent/visually appealing theming.

