### PR TITLE
Fix background reload of Oscar data causing infinite loading screen

### DIFF
--- a/src/hooks/data/useDownloadOscarData.ts
+++ b/src/hooks/data/useDownloadOscarData.ts
@@ -52,7 +52,7 @@ export default function useDownloadOscarData(
         // a background refresh from showing an error screen
         // in the middle of a session.
         // `load` will return early if it is cancelled
-        await load({ showErrors: isFirst });
+        await load({ initialLoad: isFirst });
         if (loadOperation.isCancelled) return;
 
         // Sleep for the refresh interval,
@@ -71,13 +71,15 @@ export default function useDownloadOscarData(
     }
 
     async function load({
-      showErrors,
+      initialLoad,
     }: {
-      showErrors: boolean;
+      initialLoad: boolean;
     }): Promise<void> {
-      setState({
-        type: 'loading',
-      });
+      if (initialLoad) {
+        setState({
+          type: 'loading',
+        });
+      }
 
       let attemptNumber = 1;
       while (!loadOperation.isCancelled) {
@@ -127,7 +129,7 @@ export default function useDownloadOscarData(
             );
           }
 
-          if (showErrors) {
+          if (initialLoad) {
             // Flag that an error has occurred
             setState({
               type: 'error',


### PR DESCRIPTION
### Summary

This PR ensures that the `loading` state is only set at the beginning of a background load if it is the first time the data is being loaded.

### Motivation

Right now, if a background reload of Oscar data happens but doesn't download a newer version of the data, it will cause the app to go into a loading screen that it won't ever exit (maybe unless you switch terms).

