### PR TITLE
Remove index pattern from hooks directory

### DIFF
--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -2,7 +2,9 @@ import React, { useEffect, useMemo } from 'react';
 
 import { classes } from '../../utils/misc';
 import Feedback from '../Feedback';
-import { useBodyClass, useCookie, useMobile } from '../../hooks';
+import useBodyClass from '../../hooks/useBodyClass';
+import useCookie from '../../hooks/useCookie';
+import useMobile from '../../hooks/useMobile';
 import { ThemeContext, ThemeContextValue } from '../../contexts';
 import { isTheme } from '../../types';
 import { useInformationModal } from '../InformationModal';

--- a/src/components/App/navigation.tsx
+++ b/src/components/App/navigation.tsx
@@ -7,7 +7,7 @@ import React, {
 } from 'react';
 
 import { NavDrawer, NavMenu } from '..';
-import { useMobile } from '../../hooks';
+import useMobile from '../../hooks/useMobile';
 import { ErrorWithFields } from '../../log';
 
 export const NAV_TABS = ['Scheduler', 'Map'];

--- a/src/components/Attribution/index.tsx
+++ b/src/components/Attribution/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { classes } from '../../utils/misc';
-import { useMobile } from '../../hooks';
+import useMobile from '../../hooks/useMobile';
 
 import './stylesheet.scss';
 

--- a/src/components/HeaderDisplay/index.tsx
+++ b/src/components/HeaderDisplay/index.tsx
@@ -13,7 +13,7 @@ import ReactTooltip from 'react-tooltip';
 
 import { getSemesterName } from '../../utils/misc';
 import { Button, Select, Tab } from '..';
-import { useMobile } from '../../hooks';
+import useMobile from '../../hooks/useMobile';
 import { ThemeContext } from '../../contexts';
 import { LoadingSelect } from '../Select';
 import Spinner from '../Spinner';

--- a/src/components/Scheduler/index.tsx
+++ b/src/components/Scheduler/index.tsx
@@ -3,7 +3,7 @@ import React, { useMemo, useState } from 'react';
 import { classes } from '../../utils/misc';
 import { Button, Calendar, CombinationContainer, CourseContainer } from '..';
 import { OverlayCrnsContext, OverlayCrnsContextValue } from '../../contexts';
-import { useMobile } from '../../hooks';
+import useMobile from '../../hooks/useMobile';
 
 /**
  * Wraps around the root top-level component of the Scheduler tab

--- a/src/hooks/data/useTermDataFromCookies.ts
+++ b/src/hooks/data/useTermDataFromCookies.ts
@@ -1,6 +1,6 @@
 import { useState, useMemo, useEffect, useCallback } from 'react';
 
-import { useCookie } from '..';
+import useCookie from '../useCookie';
 import { Oscar } from '../../data/beans';
 import { softError, ErrorWithFields } from '../../log';
 import {

--- a/src/hooks/data/useTermFromCookies.ts
+++ b/src/hooks/data/useTermFromCookies.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 
-import { useCookie } from '..';
+import useCookie from '../useCookie';
 import { ErrorWithFields, softError } from '../../log';
 import { LoadingState } from '../../types';
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,0 @@
-export { default as useCookie } from './useCookie';
-export { default as useMobile } from './useMobile';
-export { default as useBodyClass } from './useBodyClass';


### PR DESCRIPTION
### Summary

Removes `src/hooks/index.ts` and adjusts all imports accordingly.

### Motivation

There are few uses of `hooks`, and there are not many items in the directory, so the utility of having an index file is dubious. Removing this makes it clearer where items are being imported from, and removes a file that has to be constantly upkept to ensure it has all sibling files re-exported.
