### PR TITLE
Add test support, CI jobs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -122,6 +122,24 @@
       "rules": {
         "@typescript-eslint/explicit-function-return-type": ["error"]
       }
+    },
+    {
+      "files": ["*.test.tsx", "*.test.ts"],
+      "plugins": ["jest"],
+      "rules": {
+        // Disable unbound-method & replace with jest version
+        // https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/unbound-method.md
+        "@typescript-eslint/unbound-method": "off",
+        "jest/unbound-method": "error",
+        // Disable import/no-extraneous-dependencies for dev dependencies in test files
+        // -- some test dependencies are be dev dependencies
+        "import/no-extraneous-dependencies": [
+          "error",
+          {
+            "devDependencies": true
+          }
+        ]
+      }
     }
   ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: Continuous Integration
+on: [pull_request]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install
+        run: yarn install --frozen-lockfile
+        id: install
+
+      - name: Run prettier
+        run: yarn run format:check
+
+      - name: Run ESLint
+        run: yarn run lint
+        # Always run the linter, even if prettier failed
+        if: ${{ steps.install.outcome == 'success' }}
+
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn run build
+        env:
+          CI: "true"
+
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install
+        run: yarn install --frozen-lockfile
+
+      - name: Test
+        run: yarn run test
+        env:
+          CI: "true"

--- a/package.json
+++ b/package.json
@@ -34,9 +34,11 @@
   },
   "devDependencies": {
     "@bitwarden/cli": "^1.11.0",
+    "@testing-library/react": "^12.0.0",
     "@types/cheerio": "^0.22.30",
     "@types/dom-to-image": "^2.6.2",
     "@types/file-saver": "^2.0.1",
+    "@types/jest": "^27.0.1",
     "@types/js-cookie": "^2.2.6",
     "@types/node": "^14.14.6",
     "@types/react": "^17.0.19",
@@ -94,5 +96,11 @@
     "*.{js,jsx,ts,tsx,json}": [
       "prettier --write"
     ]
+  },
+  "jest": {
+    "restoreMocks": true,
+    "clearMocks": true,
+    "resetMocks": true,
+    "resetModules": true
   }
 }

--- a/src/components/HeaderDisplay/index.tsx
+++ b/src/components/HeaderDisplay/index.tsx
@@ -11,7 +11,7 @@ import { faGithub } from '@fortawesome/free-brands-svg-icons';
 import Cookies from 'js-cookie';
 import ReactTooltip from 'react-tooltip';
 
-import { getSemesterName } from '../../utils/misc';
+import { getSemesterName } from '../../utils/semesters';
 import { Button, Select, Tab } from '..';
 import useMobile from '../../hooks/useMobile';
 import { ThemeContext } from '../../contexts';

--- a/src/components/TermDataFallbackNotification/index.tsx
+++ b/src/components/TermDataFallbackNotification/index.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import ErrorHeader from '../ErrorHeader';
 import { BaseErrorDetails, ErrorDetailsField } from '../ErrorDetails';
 import ExpandableCard from '../ExpandableCard';
-import { getSemesterName } from '../../utils/misc';
+import { getSemesterName } from '../../utils/semesters';
 import { NonEmptyArray } from '../../types';
 
 import './stylesheet.scss';

--- a/src/utils/misc.tsx
+++ b/src/utils/misc.tsx
@@ -98,28 +98,6 @@ export const isLab = (section: Section): boolean =>
 export const isLecture = (section: Section): boolean =>
   section.scheduleType.includes('Lecture');
 
-export const getSemesterName = (term: string): string => {
-  const year = term.substring(0, 4);
-  const semester = ((): string => {
-    switch (Number.parseInt(term.substring(4), 10)) {
-      case 1:
-        return 'Winter';
-      case 2:
-      case 3:
-        return 'Spring';
-      case 5:
-      case 6:
-        return 'Summer';
-      case 8:
-      case 9:
-        return 'Fall';
-      default:
-        return 'Unknown';
-    }
-  })();
-  return `${semester} ${year}`;
-};
-
 export function humanizeArray<T>(array: T[], conjunction = 'and'): string {
   if (array.length <= 2) {
     return array.join(` ${conjunction} `);

--- a/src/utils/semesters.test.ts
+++ b/src/utils/semesters.test.ts
@@ -1,0 +1,226 @@
+import { getSemesterName, isTerm } from './semesters';
+
+describe('isTerm', () => {
+  // Tests that a list of all terms that Oscar serves (as of 2021-09-10)
+  // are all correctly identified as terms
+  it('returns true with real terms', () => {
+    const pastTerms = [
+      '202108',
+      '202105',
+      '202102',
+      '202008',
+      '202005',
+      '202002',
+      '201908',
+      '201905',
+      '201902',
+      '201808',
+      '201805',
+      '201802',
+      '201708',
+      '201705',
+      '201702',
+      '201608',
+      '201605',
+      '201602',
+      '201508',
+      '201505',
+      '201502',
+      '201408',
+      '201405',
+      '201402',
+      '201308',
+      '201305',
+      '201302',
+      '201208',
+      '201205',
+      '201202',
+      '201108',
+      '201105',
+      '201102',
+      '201008',
+      '201005',
+      '201002',
+      '200908',
+      '200905',
+      '200902',
+      '200808',
+      '200805',
+      '200802',
+      '200708',
+      '200705',
+      '200702',
+      '200608',
+      '200605',
+      '200602',
+      '200508',
+      '200505',
+      '200502',
+      '200408',
+      '200405',
+      '200402',
+      '200308',
+      '200305',
+      '200302',
+      '200208',
+      '200205',
+      '200202',
+      '200108',
+      '200105',
+      '200102',
+      '200008',
+      '200005',
+      '200002',
+      '199908',
+      '199906',
+      '199903',
+      '199901',
+      '199809',
+      '199806',
+      '199803',
+      '199801',
+      '199709',
+      '199706',
+      '199703',
+      '199701',
+      '199609',
+      '199606',
+    ];
+    pastTerms.forEach((term) => expect(isTerm(term)).toEqual(true));
+  });
+
+  // Tests that an assortment of non-term strings don't get considered terms
+  it('returns false with non-terms', () => {
+    const nonTerms = [
+      'undefined',
+      '',
+      'term',
+      'terms',
+      'visited-notice',
+      '341423',
+      '123566',
+      '000000',
+      '0',
+      '20201',
+      '2020110',
+    ];
+    nonTerms.forEach((term) => expect(isTerm(term)).toEqual(false));
+  });
+});
+
+describe('getSemesterName', () => {
+  // Tests that a list of all terms that Oscar serves (as of 2021-09-10)
+  // are all correctly formatted into the semester names
+  it('converts real terms to expected values', () => {
+    const expectedValues = {
+      '199606': 'Summer 1996',
+      '199609': 'Fall 1996',
+      '199701': 'Winter 1997',
+      '199703': 'Spring 1997',
+      '199706': 'Summer 1997',
+      '199709': 'Fall 1997',
+      '199801': 'Winter 1998',
+      '199803': 'Spring 1998',
+      '199806': 'Summer 1998',
+      '199809': 'Fall 1998',
+      '199901': 'Winter 1999',
+      '199903': 'Spring 1999',
+      '199906': 'Summer 1999',
+      // Trivia: August 1999 is when Georgia Tech switched
+      // from a quarter system to a semester system.
+      // Source: https://registrar.gatech.edu/info/semester-system
+      '199908': 'Fall 1999',
+      '200002': 'Spring 2000',
+      '200005': 'Summer 2000',
+      '200008': 'Fall 2000',
+      '200102': 'Spring 2001',
+      '200105': 'Summer 2001',
+      '200108': 'Fall 2001',
+      '200202': 'Spring 2002',
+      '200205': 'Summer 2002',
+      '200208': 'Fall 2002',
+      '200302': 'Spring 2003',
+      '200305': 'Summer 2003',
+      '200308': 'Fall 2003',
+      '200402': 'Spring 2004',
+      '200405': 'Summer 2004',
+      '200408': 'Fall 2004',
+      '200502': 'Spring 2005',
+      '200505': 'Summer 2005',
+      '200508': 'Fall 2005',
+      '200602': 'Spring 2006',
+      '200605': 'Summer 2006',
+      '200608': 'Fall 2006',
+      '200702': 'Spring 2007',
+      '200705': 'Summer 2007',
+      '200708': 'Fall 2007',
+      '200802': 'Spring 2008',
+      '200805': 'Summer 2008',
+      '200808': 'Fall 2008',
+      '200902': 'Spring 2009',
+      '200905': 'Summer 2009',
+      '200908': 'Fall 2009',
+      '201002': 'Spring 2010',
+      '201005': 'Summer 2010',
+      '201008': 'Fall 2010',
+      '201102': 'Spring 2011',
+      '201105': 'Summer 2011',
+      '201108': 'Fall 2011',
+      '201202': 'Spring 2012',
+      '201205': 'Summer 2012',
+      '201208': 'Fall 2012',
+      '201302': 'Spring 2013',
+      '201305': 'Summer 2013',
+      '201308': 'Fall 2013',
+      '201402': 'Spring 2014',
+      '201405': 'Summer 2014',
+      '201408': 'Fall 2014',
+      '201502': 'Spring 2015',
+      '201505': 'Summer 2015',
+      '201508': 'Fall 2015',
+      '201602': 'Spring 2016',
+      '201605': 'Summer 2016',
+      '201608': 'Fall 2016',
+      '201702': 'Spring 2017',
+      '201705': 'Summer 2017',
+      '201708': 'Fall 2017',
+      '201802': 'Spring 2018',
+      '201805': 'Summer 2018',
+      '201808': 'Fall 2018',
+      '201902': 'Spring 2019',
+      '201905': 'Summer 2019',
+      '201908': 'Fall 2019',
+      '202002': 'Spring 2020',
+      '202005': 'Summer 2020',
+      '202008': 'Fall 2020',
+      '202102': 'Spring 2021',
+      '202105': 'Summer 2021',
+      '202108': 'Fall 2021',
+    };
+
+    Object.entries(expectedValues).forEach(([term, semesterName]) =>
+      expect(getSemesterName(term)).toEqual(semesterName)
+    );
+  });
+
+  // Tests that an assortment of non-term strings
+  // get turned into a fallback "semester name"
+  it('converts non-terms to "Unknown"', () => {
+    const nonTerms = [
+      'undefined',
+      '',
+      'term',
+      'terms',
+      'visited-notice',
+      '341423',
+      '123566',
+      '000000',
+      '0',
+      '20201',
+      '2020110',
+    ];
+    nonTerms.forEach((term) =>
+      expect(getSemesterName(term)).toEqual('Unknown')
+    );
+  });
+});

--- a/src/utils/semesters.ts
+++ b/src/utils/semesters.ts
@@ -1,0 +1,43 @@
+/**
+ * Tries to guess whether a term string is really a term or not.
+ * Terms are of the form "202008", where the first 4 digits are a year
+ * and the last 2 are a month.
+ */
+export function isTerm(maybeTerm: string): boolean {
+  if (maybeTerm.length !== 6) return false;
+  const [year, month] = [maybeTerm.substring(0, 4), maybeTerm.substring(4, 6)];
+  const [yearAsNumber, monthAsNumber] = [Number(year), Number(month)];
+  if (Number.isNaN(yearAsNumber) || yearAsNumber < 1970 || monthAsNumber > 2100)
+    return false;
+  if (Number.isNaN(monthAsNumber) || monthAsNumber < 0 || monthAsNumber > 12)
+    return false;
+
+  return true;
+}
+
+/**
+ * Gets the human-facing display name of a term/semester
+ */
+export function getSemesterName(term: string): string {
+  if (!isTerm(term)) return 'Unknown';
+
+  const year = term.substring(0, 4);
+  const semester = ((): string => {
+    switch (Number.parseInt(term.substring(4), 10)) {
+      case 1:
+        return 'Winter';
+      case 2:
+      case 3:
+        return 'Spring';
+      case 5:
+      case 6:
+        return 'Summer';
+      case 8:
+      case 9:
+        return 'Fall';
+      default:
+        return 'Unknown';
+    }
+  })();
+  return `${semester} ${year}`;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1360,6 +1360,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.5":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.4.tgz#fd17d16bfdf878e6dd02d19753a39fa8a8d9c84a"
+  integrity sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4":
   version "7.10.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.5.tgz#303d8bd440ecd5a491eae6117fd3367698674c5c"
@@ -1756,6 +1763,17 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@jest/types@^27.1.1":
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.1.1.tgz#77a3fc014f906c65752d12123a0134359707c0ad"
+  integrity sha512-yqJPDDseb0mXgKqmNqypCsb85C22K1aY5+LUxh7syIM9n/b0AsaltxNy+o6tt29VcfGDpYEve175bm3uOhcehA==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^16.0.0"
+    chalk "^4.0.0"
+
 "@mapbox/geojson-rewind@^0.5.0":
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/@mapbox/geojson-rewind/-/geojson-rewind-0.5.1.tgz#adbe16dc683eb40e90934c51a5e28c7bbf44f4e1"
@@ -2105,10 +2123,37 @@
   dependencies:
     "@sweetalert/transformer" "^0.1.1"
 
+"@testing-library/dom@^8.0.0":
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.5.0.tgz#56e31331015f943a68c6ec27e259fdf16c69ab7d"
+  integrity sha512-O0fmHFaPlqaYCpa/cBL0cvroMridb9vZsMLacgIqrlxj+fd+bGF8UfAgwsLCHRF84KLBafWlm9CuOvxeNTlodw==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.6"
+    lz-string "^1.4.4"
+    pretty-format "^27.0.2"
+
+"@testing-library/react@^12.0.0":
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.0.tgz#3e9a4002b0b8f986a738a2f88fc458b5af319f35"
+  integrity sha512-Ge3Ht3qXE82Yv9lyPpQ7ZWgzo/HgOcHu569Y4ZGWcZME38iOFiOg87qnu6hTEa8jTJVL7zYovnvD3GE2nsNIoQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^8.0.0"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+
+"@types/aria-query@^4.2.0":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"
+  integrity sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.15"
@@ -2233,6 +2278,14 @@
   integrity sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==
   dependencies:
     "@types/istanbul-lib-report" "*"
+
+"@types/jest@^27.0.1":
+  version "27.0.1"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.0.1.tgz#fafcc997da0135865311bb1215ba16dba6bdf4ca"
+  integrity sha512-HTLpVXHrY69556ozYkcq47TtQJXpcWAWfkoqz+ZGz2JnmZhzlRjprCIyFnetSy8gpDWwTTGBcRVv1J1I1vBrHw==
+  dependencies:
+    jest-diff "^27.0.0"
+    pretty-format "^27.0.0"
 
 "@types/js-cookie@^2.2.6":
   version "2.2.7"
@@ -2392,6 +2445,13 @@
   version "15.0.14"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.14.tgz#26d821ddb89e70492160b66d10a0eb6df8f6fb06"
   integrity sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^16.0.0":
+  version "16.0.4"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-16.0.4.tgz#26aad98dd2c2a38e421086ea9ad42b9e51642977"
+  integrity sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -2896,6 +2956,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
+
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 anymatch@^2.0.0:
   version "2.0.0"
@@ -4971,6 +5036,11 @@ diff-sequences@^26.6.2:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
   integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
 
+diff-sequences@^27.0.6:
+  version "27.0.6"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.0.6.tgz#3305cb2e55a033924054695cc66019fd7f8e5723"
+  integrity sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==
+
 diffie-hellman@^5.0.0:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
@@ -5020,6 +5090,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.5.6:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.7.tgz#8c2aa6325968f2933160a0b7dbb380893ddf3e7d"
+  integrity sha512-ml3lJIq9YjUfM9TUnEPvEYWFSwivwIGBPKpewX7tii7fwCazA8yCioGdqQcNsItPpfFvSJ3VIdMQPj60LJhcQA==
 
 dom-converter@^0.2:
   version "0.2.0"
@@ -7776,6 +7851,16 @@ jest-diff@^26.6.2:
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
 
+jest-diff@^27.0.0:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.1.1.tgz#1d1629ca2e3933b10cb27dc260e28e3dba182684"
+  integrity sha512-m/6n5158rqEriTazqHtBpOa2B/gGgXJijX6nsEgZfbJ/3pxQcdpVXBe+FP39b1dxWHyLVVmuVXddmAwtqFO4Lg==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^27.0.6"
+    jest-get-type "^27.0.6"
+    pretty-format "^27.1.1"
+
 jest-docblock@^26.0.0:
   version "26.0.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-26.0.0.tgz#3e2fa20899fc928cb13bd0ff68bd3711a36889b5"
@@ -7823,6 +7908,11 @@ jest-get-type@^26.3.0:
   version "26.3.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
   integrity sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==
+
+jest-get-type@^27.0.6:
+  version "27.0.6"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.0.6.tgz#0eb5c7f755854279ce9b68a9f1a4122f69047cfe"
+  integrity sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==
 
 jest-haste-map@^26.6.2:
   version "26.6.2"
@@ -8672,6 +8762,11 @@ lunr@2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.3.tgz#5a72d170c872e441e7d0ffb61fff76b499ac0780"
   integrity sha512-rlAEsgU9Bnavca2w1WJ6+6cdeHMXNyadcersyk3ZpuhgWb5HBNj8l4WwJz9PjksAhYDlpQffCVXPctOn+wCIVA==
+
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
 
 magic-string@^0.25.0, magic-string@^0.25.7:
   version "0.25.7"
@@ -10750,6 +10845,16 @@ pretty-format@^26.6.0, pretty-format@^26.6.2:
     "@jest/types" "^26.6.2"
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
+    react-is "^17.0.1"
+
+pretty-format@^27.0.0, pretty-format@^27.0.2, pretty-format@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.1.1.tgz#cbaf9ec6cd7cfc3141478b6f6293c0ccdbe968e0"
+  integrity sha512-zdBi/xlstKJL42UH7goQti5Hip/B415w1Mfj+WWWYMBylAYtKESnXGUtVVcMVid9ReVjypCotUV6CEevYPHv2g==
+  dependencies:
+    "@jest/types" "^27.1.1"
+    ansi-regex "^5.0.0"
+    ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
 process-nextick-args@~2.0.0:


### PR DESCRIPTION
### Summary

This PR adds an example usage of the testing framework that create-react-app provides, in addition to a couple libraries/lint rules to make testing easier. Finally, it includes 3 new GitHub actions to handle CI for linting, building, and test-running, respectively (these all take on the order of 1-2 minutes, so they shouldn't negatively affect waiting very much).

### Summary

Better code quality with unit tests, and more confidence when merging with CI checks.
