### PR TITLE
Make terms context read-only

### DIFF
--- a/src/components/HeaderDisplay/index.tsx
+++ b/src/components/HeaderDisplay/index.tsx
@@ -28,7 +28,7 @@ export type HeaderDisplayProps = {
     | { type: 'loading' }
     | {
         type: 'loaded';
-        terms: string[];
+        terms: readonly string[];
         currentTerm: string;
         onChangeTerm: (next: string) => void;
       };

--- a/src/contexts/terms.ts
+++ b/src/contexts/terms.ts
@@ -1,4 +1,4 @@
 import React from 'react';
 
-export type TermsContextValue = string[];
+export type TermsContextValue = readonly string[];
 export const TermsContext = React.createContext<TermsContextValue>([]);


### PR DESCRIPTION
### Summary

Makes the value of `TermsContext` (the list of available terms) readonly so that it can't be inadvertently mutated.

