### PR TITLE
Improve styles in <Select>, <Feedback>

### DIFF
--- a/src/components/Feedback/stylesheet.scss
+++ b/src/components/Feedback/stylesheet.scss
@@ -15,17 +15,21 @@
 }
 
 %common {
-  // Include theme switch transition
-  transition-duration: $theme-switch-transition-duration;
-  transition-property: background-color;
-
   @include dark {
-    background-color: $theme-dark-card-background;
+    --feedback-outer-color: #{$theme-dark-card-background};
+    --feedback-inner-color: #{$theme-dark-background};
   }
 
   @include light {
-    background-color: $theme-light-background;
+    --feedback-outer-color: #{$theme-light-background};
+    --feedback-inner-color: #{$theme-light-card-background};
   }
+  
+  background-color: var(--feedback-outer-color);
+
+  // Include theme switch transition
+  transition-duration: $theme-switch-transition-duration;
+  transition-property: background-color;
 }
 
 .FeedbackButton {
@@ -75,8 +79,12 @@
     & div {
       display: inline-block;
       justify-content: space-around;
-      background-color: var(--theme-bg);
+      background-color: var(--feedback-inner-color);
       text-align: center;
+
+      // Include theme switch transition
+      transition-duration: $theme-switch-transition-duration;
+      transition-property: background-color;
     }
   }
   
@@ -87,6 +95,7 @@
     border-radius: 5px;
     &.active {
       background-color: #429bda;
+      color: white;
     }
   }
 
@@ -113,7 +122,7 @@
     font-size: 16px;
     resize: none;
     border-radius: 5px;
-    background-color: var(--theme-bg);
+    background-color: var(--feedback-inner-color);
     color: currentColor;
     padding: 8px;
 
@@ -137,6 +146,7 @@
     border-radius: 5px;
     margin-left: auto;
     margin-right: auto;
+    color: white;
   }
   
   .CloseIcon {

--- a/src/components/Select/stylesheet.scss
+++ b/src/components/Select/stylesheet.scss
@@ -15,10 +15,12 @@
     bottom: 0;
     left: 0;
     right: 0;
+    cursor: default;
   }
 
   .option-container {
-    @include card;
+    @include popup;
+
     margin: 0;
     z-index: 1;
     position: absolute;
@@ -28,21 +30,21 @@
     max-height: 240px;
     overflow-y: auto;
 
+    @include dark {
+      background-color: $theme-dark-card-background;
+    }
+
+    @include light {
+      background-color: $theme-light-background;
+    }
+
     .option {
       justify-content: flex-start;
       white-space: nowrap;
     }
   }
-}
 
-.dark .Select {
-  .option-container {
-    background-color: $theme-dark-background;
-  }
-}
-
-.light .Select {
-  .option-container {
-    background-color: $theme-light-background;
+  *::-webkit-scrollbar {
+    display: none;
   }
 }


### PR DESCRIPTION
### Summary

This PR contains minor improvements to the styles for the `<Select>` and `<Feedback>` components.

### Motivation

Increase the contrast for the `<Select>` drop-down box on dark mode, and fix the contrast being inadvertently removed for the `<Feedback>`'s form on light mode.
