### PR TITLE
Rename "development" to "main"

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,7 +2,7 @@ name: Deploy
 on:
   push:
     branches:
-      - development
+      - main
 
 jobs:
   build-and-deploy:
@@ -22,7 +22,7 @@ jobs:
       - name: Build
         run: yarn build
         env:
-          CI: "true"
+          CI: 'true'
           REACT_APP_MAPBOX_TOKEN: ${{ secrets.REACT_APP_MAPBOX_TOKEN }}
           REACT_APP_SENTRY_VERSION: ${{ github.sha }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,10 +33,7 @@ We welcome community contributions to the GT Scheduler project! Please read each
    ```
 
 1. Do whatever the Issue asks in your branch (whether that be implementing a new feature or fixing an existing bug)
-1. Make a PR between your branch and the appropriate primary branch that links to the Issue you want to resolve. The exact branch depends on the repository you are making a PR to:
-   - For the [website repo](https://github.com/gt-scheduler/website), the appropriate branch is `development`
-   - For the [crawler repo](https://github.com/gt-scheduler/crawler), the appropriate branch is `main`
-   - For the [backend repo](https://github.com/gt-scheduler/backend), the appropriate branch is `main`
+1. Make a PR between your branch and the primary branch (`main`) that links to the Issue you want to resolve.
 1. Get at least one other contributor to review your PR and make comments when necessary.
 1. Merge your PR once it has been approved!
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To implement its goal of facilitating schedule creation and class exploration, G
 - Seating information for a single section, which is requested on demand and sent through our CORS proxy in the [Backend application](https://api.github.com/repos/gt-scheduler/crawler/) to [Oscar](https://oscar.gatech.edu/) (Georgia Tech's registration management system): https://gt-scheduler.azurewebsites.net/proxy/class_section?term=202008&crn=87086
 - Course/instructor GPA information, which is fetched from [Course Critique](https://critique.gatech.edu/)'s API: https://c4citk6s9k.execute-api.us-east-1.amazonaws.com/test/data/course?courseID=CS%201331
 
-Once features are merged into the `development` branch, they are automatically deployed to the `gh-pages` branch using a [GitHub Action workflow](https://github.com/gt-scheduler/website/blob/development/.github/workflows/deploy.yml). This branch is set up to serve traffic to the public site, https://gt-scheduler.org/, using the [GitHub Pages](https://pages.github.com/) service.
+Once features are merged into the `main` branch, they are automatically deployed to the `gh-pages` branch using a [GitHub Action workflow](https://github.com/gt-scheduler/website/blob/main/.github/workflows/deploy.yml). This branch is set up to serve traffic to the public site, https://gt-scheduler.org/, using the [GitHub Pages](https://pages.github.com/) service.
 
 The website uses [Google Analytics](https://marketingplatform.google.com/about/analytics/) for aggregate analytics and information about how many people are using the app. It also utilizes [Sentry](https://sentry.io/welcome/) for automatic error reporting.
 


### PR DESCRIPTION
### Summary

This PR changes all references to "development" to "main".

### Motivation

Resolves #95 
