### PR TITLE
Use "use-local-storage-state" for feature flag

### DIFF
--- a/src/hooks/useFeatureFlag.ts
+++ b/src/hooks/useFeatureFlag.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import useLocalStorageState from 'use-local-storage-state';
 
 /**
  * Used to gate certain features behind opt-in developer feature flags.
@@ -7,42 +7,6 @@ import { useEffect, useState } from 'react';
  */
 export default function useFeatureFlag(date: string, key: string): boolean {
   const derivedKey = `ff-${date}-${key}`;
-  const [isEnabled, setIsEnabled] = useState<boolean>(() => {
-    try {
-      if (window.localStorage.getItem(derivedKey) === 'true') return true;
-      return false;
-    } catch (_) {
-      // Ignore
-      return false;
-    }
-  });
-
-  // Subscribe to updates
-  useEffect(() => {
-    const listener = (event: StorageEvent): void => {
-      try {
-        if (event.storageArea === localStorage && event.key === derivedKey) {
-          setIsEnabled(event.newValue === 'true');
-        }
-      } catch (_) {
-        // Ignore
-      }
-    };
-
-    try {
-      window.addEventListener('storage', listener, false);
-      return (): void => {
-        try {
-          window.removeEventListener('storage', listener, false);
-        } catch (_) {
-          // Ignore
-        }
-      };
-    } catch (_) {
-      // Ignore
-      return (): void => undefined;
-    }
-  });
-
+  const [isEnabled] = useLocalStorageState<boolean>(derivedKey, false);
   return isEnabled;
 }


### PR DESCRIPTION
### Summary

This PR simplifies the implementation of `useFeatureFlag` by using `use-local-storage-state` to do the heavy-lifting of managing state and subscribing to updates.

