### PR TITLE
Add CI config to inject firebase config in prod

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,8 +23,17 @@ jobs:
         run: yarn build
         env:
           CI: 'true'
+          # None of these values are actually secret;
+          # they all get included in the final bundle.
           REACT_APP_MAPBOX_TOKEN: ${{ secrets.REACT_APP_MAPBOX_TOKEN }}
           REACT_APP_SENTRY_VERSION: ${{ github.sha }}
+          REACT_APP_FIREBASE_API_KEY: ${{ secrets.REACT_APP_FIREBASE_API_KEY }}
+          REACT_APP_FIREBASE_AUTH_DOMAIN: ${{ secrets.REACT_APP_FIREBASE_AUTH_DOMAIN }}
+          REACT_APP_FIREBASE_PROJECT_ID: ${{ secrets.REACT_APP_FIREBASE_PROJECT_ID }}
+          REACT_APP_FIREBASE_STORAGE_BUCKET: ${{ secrets.REACT_APP_FIREBASE_STORAGE_BUCKET }}
+          REACT_APP_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.REACT_APP_FIREBASE_MESSAGING_SENDER_ID }}
+          REACT_APP_FIREBASE_APP_ID: ${{ secrets.REACT_APP_FIREBASE_APP_ID }}
+          REACT_APP_FIREBASE_MEASUREMENT_ID: ${{ secrets.REACT_APP_FIREBASE_MEASUREMENT_ID }}
 
       - name: Create Sentry release
         uses: getsentry/action-release@v1

--- a/src/data/firebase.ts
+++ b/src/data/firebase.ts
@@ -14,6 +14,7 @@ const firebaseConfig = {
   storageBucket: process.env['REACT_APP_FIREBASE_STORAGE_BUCKET'],
   messagingSenderId: process.env['REACT_APP_FIREBASE_MESSAGING_SENDER_ID'],
   appId: process.env['REACT_APP_FIREBASE_APP_ID'],
+  measurementId: process.env['REACT_APP_FIREBASE_MEASUREMENT_ID'],
 };
 
 /**


### PR DESCRIPTION
### Summary

This PR changes the GitHub Actions CI to add in the required Firebase config environment variables when building (the variables come from the repository's secrets, which I have already added). Note: none of these values are actually secret; they all get included in the final bundle.
