### PR TITLE
Replace GitHub API with self-hosted index

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ The app is a React single-page application (SPA) (built using [`create-react-app
 
 To implement its goal of facilitating schedule creation and class exploration, GT Scheduler stores all data **locally in cookies**. Then, it sources any relevant data at runtime from a variety of sources, such as:
 
-- The list of terms (strings like `202008`, which corresponds to Fall 2020) that have been scraped by the [Crawler application](https://api.github.com/repos/gt-scheduler/crawler/): https://api.github.com/repos/gt-scheduler/crawler/contents?ref=gh-pages
-- The data for a single term, which is the full output of the Cralwer application in a single JSON file: https://raw.githubusercontent.com/gt-scheduler/crawler/gh-pages/202008.json
+- The list of terms (strings like `202008`, which corresponds to Fall 2020) that have been scraped by the [Crawler application](https://api.github.com/repos/gt-scheduler/crawler/): https://gt-scheduler.github.io/crawler/index.json
+- The data for a single term, which is the full output of the Cralwer application in a single JSON file: https://gt-scheduler.github.io/crawler/202008.json
 - Seating information for a single section, which is requested on demand and sent through our CORS proxy in the [Backend application](https://api.github.com/repos/gt-scheduler/crawler/) to [Oscar](https://oscar.gatech.edu/) (Georgia Tech's registration management system): https://gt-scheduler.azurewebsites.net/proxy/class_section?term=202008&crn=87086
 - Course/instructor GPA information, which is fetched from [Course Critique](https://critique.gatech.edu/)'s API: https://c4citk6s9k.execute-api.us-east-1.amazonaws.com/test/data/course?courseID=CS%201331
 

--- a/src/components/AppDataLoader/stages.tsx
+++ b/src/components/AppDataLoader/stages.tsx
@@ -37,7 +37,7 @@ import useRawScheduleDataFromFirebase from '../../data/hooks/useRawScheduleDataF
 // (like having a valid current term/version),
 // where an operation depends on the results of previous action(s).
 // For example, ensuring that the current term is valid
-// depends on fetching the list of terms from the GitHub API,
+// depends on fetching the list of terms from the crawler's index,
 // so having them be two separate stages naturally encodes this dependency.
 // It also lets us stop rendering the app when data is still loading,
 // and instead show a partially interactive "skeleton".
@@ -347,7 +347,7 @@ export type StageLoadTermsProps = {
 };
 
 /**
- * Handles loading the list of terms from the GitHub API upon first mount,
+ * Handles loading the list of terms from the crawler's index upon first mount,
  * showing loading and error states as needed.
  * Renders a disabled header & attribution footer even when loading.
  */


### PR DESCRIPTION
### Summary

This PR makes the website use the crawler's self-hosted index of crawled terms, instead of using the GitHub API. This gets around rate-limiting that the GitHub API previously enforced. The crawler implementation is in https://github.com/gt-scheduler/crawler/pull/9.

### Motivation

This PR fixes #96 

