### PR TITLE
Fix lab/lecture section matching

### DIFF
--- a/src/data/beans/Section.ts
+++ b/src/data/beans/Section.ts
@@ -109,7 +109,7 @@ export default class Section {
         where,
         location: oscar.locations[locationIndex] ?? null,
         instructors: instructors.map((instructor) =>
-          instructor.replace(/ \(P\)$/, '')
+          instructor.replace(/ \(P\)$/, '').trim()
         ),
         // We need some fallback here
         dateRange: oscar.dateRanges[dateRangeIndex] ?? {


### PR DESCRIPTION
Co-authored-by: @AlexanderPuckhaber

> Changed lab/lecture section matching to be symmetric due to an issue with MATH 1553. Also, added failover matching to match by the intersection of lab/lecture profs

Resolves #42 

Supersedes #43 
