### PR TITLE
Remove the cookie fallback from the info modal

### DIFF
--- a/src/components/InformationModal/index.tsx
+++ b/src/components/InformationModal/index.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import Cookies from 'js-cookie';
 import useLocalStorageState from 'use-local-storage-state';
 
 import Modal from '../Modal';
@@ -110,11 +109,7 @@ export default function InformationModal(): React.ReactElement {
   const [show, setShow] = useState(false);
   const [hasSeen, setHasSeen] = useLocalStorageState(
     MODAL_LOCAL_STORAGE_KEY,
-    () => {
-      const cookieValue = Cookies.get(MODAL_LOCAL_STORAGE_KEY);
-      if (cookieValue === 'true') return true;
-      return false;
-    }
+    false
   );
 
   useEffect(() => {


### PR DESCRIPTION
### Summary

This PR removes the cookie fallback from the `<InformationalModal>`'s 'seen' state. The original reason this was present was for the migration notice modal. Since that has been replaced by the Spring 2022 feature release modal, it's no longer necessary to include the cookie fallback.
