### PR TITLE
Add persistent cache in front of course critique API

### DIFF
--- a/src/data/beans/Course.ts
+++ b/src/data/beans/Course.ts
@@ -217,13 +217,13 @@ export default class Course {
       const rawCache = window.localStorage.getItem(GPA_CACHE_LOCAL_STORAGE_KEY);
       if (rawCache != null) {
         const cache: GpaCache = JSON.parse(rawCache) as unknown as GpaCache;
-        const cache_item = cache[this.id];
-        if (cache_item != null) {
+        const cacheItem = cache[this.id];
+        if (cacheItem != null) {
           const now = new Date().toISOString();
           // Use lexicographic comparison on date strings
           // (since they are ISO 8601)
-          if (now < cache_item.exp) {
-            return cache_item.d;
+          if (now < cacheItem.exp) {
+            return cacheItem.d;
           }
         }
       }

--- a/src/data/beans/Course.ts
+++ b/src/data/beans/Course.ts
@@ -193,6 +193,24 @@ export default class Course {
   }
 
   async fetchGpa(): Promise<CourseGpa> {
+    const courseGpa = await this.fetchGpaInner();
+    if (courseGpa === null) {
+      return {};
+    }
+
+    return courseGpa;
+  }
+
+  /**
+   * Fetches the course GPA without caching it
+   * @see `fetchGpa` for the persistent-caching version
+   * @returns the course GPA if successfully fetched from course critique,
+   * or `null` if there was a problem.
+   * Note that the empty object `{}` is a valid course GPA value,
+   * but we prefer returning `null` if there was a failure
+   * so we can avoid storing the empty GPA value in the persistent cache.
+   */
+  private async fetchGpaInner(): Promise<CourseGpa | null> {
     const base =
       'https://c4citk6s9k.execute-api.us-east-1.amazonaws.com/test/data';
     // We have to clean up the course ID before sending it to the API,

--- a/src/data/beans/Course.ts
+++ b/src/data/beans/Course.ts
@@ -15,6 +15,9 @@ import {
 } from '../../utils/misc';
 import { ErrorWithFields, softError } from '../../log';
 
+const COURSE_CRITIQUE_API_URL =
+  'https://c4citk6s9k.execute-api.us-east-1.amazonaws.com/test/data';
+
 interface SectionGroupMeeting {
   days: string[];
   period: Period | undefined;
@@ -211,13 +214,11 @@ export default class Course {
    * so we can avoid storing the empty GPA value in the persistent cache.
    */
   private async fetchGpaInner(): Promise<CourseGpa | null> {
-    const base =
-      'https://c4citk6s9k.execute-api.us-east-1.amazonaws.com/test/data';
     // We have to clean up the course ID before sending it to the API,
     // since courses like CHEM 1212K should become CHEM 1212
     const id = `${this.subject} ${this.number.replace(/\D/g, '')}`;
     const encodedCourse = encodeURIComponent(id);
-    const url = `${base}/course?courseID=${encodedCourse}`;
+    const url = `${COURSE_CRITIQUE_API_URL}/course?courseID=${encodedCourse}`;
 
     let responseData: CourseDetailsAPIResponse;
     try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,10 @@ export interface Meeting {
   dateRange: DateRange;
 }
 
+// Note: if this type ever changes,
+// the course gpa cache needs to be invalidated
+// (by changing the local storage key).
+// See `src/data/beans/Course.ts` for the implementation of the cache.
 export interface CourseGpa {
   averageGpa?: number;
   [instructor: string]: number | undefined;


### PR DESCRIPTION
### Summary

This PR adds a local persistent cache in front of the Course Critique API that will cache course GPA data objects for a week after they are fetched. This helps to reduce the number of API requests in the following scenarios:

- When the page is refreshed
- When the schedule version is switched to another version that has some or all of the same courses selected
- When the term is switched to another term that has some or all of the same courses selected (on whatever schedule version is currently selected)

### Motivation

Reduce traffic to the Course Critique API without introducing our own centralized cache.

Note: right now their API is serving 500s for all requests to the endpoint we're using (https://c4citk6s9k.execute-api.us-east-1.amazonaws.com/test/data), and these responses **will not** be cached, so this mechanism will only start reducing traffic to their API once it starts serving 200 responses.
