### PR TITLE
Fix local course GPA cache to skip storing empty data

### DIFF
--- a/src/data/beans/Course.ts
+++ b/src/data/beans/Course.ts
@@ -16,7 +16,7 @@ import {
 import { ErrorWithFields, softError } from '../../log';
 
 const COURSE_CRITIQUE_API_URL =
-  'https://c4citk6s9k.execute-api.us-east-1.amazonaws.com/test/data/course';
+  'https://c4citk6s9k.execute-api.us-east-1.amazonaws.com/test/data';
 
 const GPA_CACHE_LOCAL_STORAGE_KEY = 'course-gpa-cache-2';
 const GPA_CACHE_EXPIRATION_DURATION_DAYS = 7;
@@ -272,7 +272,7 @@ export default class Course {
     // since courses like CHEM 1212K should become CHEM 1212
     const id = `${this.subject} ${this.number.replace(/\D/g, '')}`;
     const encodedCourse = encodeURIComponent(id);
-    const url = `${COURSE_CRITIQUE_API_URL}?courseID=${encodedCourse}`;
+    const url = `${COURSE_CRITIQUE_API_URL}/course?courseID=${encodedCourse}`;
 
     let responseData: CourseDetailsAPIResponse;
     try {

--- a/src/data/beans/Course.ts
+++ b/src/data/beans/Course.ts
@@ -16,9 +16,9 @@ import {
 import { ErrorWithFields, softError } from '../../log';
 
 const COURSE_CRITIQUE_API_URL =
-  'https://c4citk6s9k.execute-api.us-east-1.amazonaws.com/test/data';
+  'https://c4citk6s9k.execute-api.us-east-1.amazonaws.com/test/data/course';
 
-const GPA_CACHE_LOCAL_STORAGE_KEY = 'course-gpa-cache';
+const GPA_CACHE_LOCAL_STORAGE_KEY = 'course-gpa-cache-2';
 const GPA_CACHE_EXPIRATION_DURATION_DAYS = 7;
 
 interface SectionGroupMeeting {
@@ -272,7 +272,7 @@ export default class Course {
     // since courses like CHEM 1212K should become CHEM 1212
     const id = `${this.subject} ${this.number.replace(/\D/g, '')}`;
     const encodedCourse = encodeURIComponent(id);
-    const url = `${COURSE_CRITIQUE_API_URL}/course?courseID=${encodedCourse}`;
+    const url = `${COURSE_CRITIQUE_API_URL}?courseID=${encodedCourse}`;
 
     let responseData: CourseDetailsAPIResponse;
     try {
@@ -294,7 +294,7 @@ export default class Course {
         );
       }
 
-      return {};
+      return null;
     }
 
     // Extract the relevant fields from the response
@@ -369,7 +369,7 @@ export default class Course {
           },
         })
       );
-      return {};
+      return null;
     }
   }
 }


### PR DESCRIPTION
### Summary

This PR fixes a bug added with #118 where course data would get stored (as empty data (`{}`) even if an error occurred making the request or parsing the data. The original PR intended to explicitly avoid this pit-fall, but ended up failing to do so. To fix this, the local storage key also needs to be changed to discard the old cached values.

This PR won't fix course GPAs not appearing on the scheduler; this requires re-gaining access to the Course Critique API.