### PR TITLE
Remove new user greeting modal because dates and info are outdated

### DIFF
--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -66,7 +66,7 @@ export default function App(): React.ReactElement {
           <Feedback />
 
           {/* Display a popup when first visiting the site */}
-          <InformationModal />
+          {/* <InformationModal /> */}
         </ErrorBoundary>
       </AppCSSRoot>
     </ThemeContext.Provider>


### PR DESCRIPTION
<img width="1786" alt="image" src="https://user-images.githubusercontent.com/39681900/198898025-84066d73-4c72-41a0-8496-1d99cdb16f0a.png">
This modal is outdated as of October 30, 2022, meaning it doesn't show new information and dates are not correct. Until new updates are released and design for new modal is made, this greeting modal will be commented out.