### PR TITLE
Use non-default uid for ical export

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "react-virtualized": "^9.21.2",
     "s-ago": "^2.2.0",
     "tslib": "2.3.0",
-    "use-local-storage-state": "^11.0.0"
+    "use-local-storage-state": "^11.0.0",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@bitwarden/cli": "^2022.8.0",

--- a/src/hooks/useHeaderActionBarProps.ts
+++ b/src/hooks/useHeaderActionBarProps.ts
@@ -26,13 +26,13 @@ export type HookResult = Pick<
 export default function useHeaderActionBarProps(
   captureRef: React.RefObject<HTMLDivElement>
 ): HookResult {
-  const [{ oscar, pinnedCrns }] = useContext(ScheduleContext);
+  const [{ term, oscar, pinnedCrns }] = useContext(ScheduleContext);
   const [theme] = useContext(ThemeContext);
   const accountState = useContext(AccountContext);
 
   const handleExport = useCallback(() => {
     try {
-      exportCoursesToCalendar(oscar, pinnedCrns);
+      exportCoursesToCalendar(term, oscar, pinnedCrns);
     } catch (err) {
       softError(
         new ErrorWithFields({
@@ -44,7 +44,7 @@ export default function useHeaderActionBarProps(
         })
       );
     }
-  }, [oscar, pinnedCrns]);
+  }, [term, oscar, pinnedCrns]);
 
   const handleDownload = useCallback(() => {
     const captureElement = captureRef.current;

--- a/src/hooks/useHeaderActionBarProps.ts
+++ b/src/hooks/useHeaderActionBarProps.ts
@@ -26,13 +26,13 @@ export type HookResult = Pick<
 export default function useHeaderActionBarProps(
   captureRef: React.RefObject<HTMLDivElement>
 ): HookResult {
-  const [{ term, oscar, pinnedCrns }] = useContext(ScheduleContext);
+  const [{ oscar, pinnedCrns }] = useContext(ScheduleContext);
   const [theme] = useContext(ThemeContext);
   const accountState = useContext(AccountContext);
 
   const handleExport = useCallback(() => {
     try {
-      exportCoursesToCalendar(term, oscar, pinnedCrns);
+      exportCoursesToCalendar(oscar, pinnedCrns);
     } catch (err) {
       softError(
         new ErrorWithFields({
@@ -44,7 +44,7 @@ export default function useHeaderActionBarProps(
         })
       );
     }
-  }, [term, oscar, pinnedCrns]);
+  }, [oscar, pinnedCrns]);
 
   const handleDownload = useCallback(() => {
     const captureElement = captureRef.current;

--- a/src/utils/misc.tsx
+++ b/src/utils/misc.tsx
@@ -216,11 +216,10 @@ export async function sleep({
  * which allows for importing into a third-party calendar application.
  */
 export function exportCoursesToCalendar(
-  term: string,
   oscar: Oscar,
   pinnedCrns: readonly string[]
 ): void {
-  const cal = ics(`gt-scheduler-${term}`) as ICS | undefined;
+  const cal = ics('gt-scheduler') as ICS | undefined;
   if (cal == null) {
     window.alert('This browser does not support calendar export');
     softError(

--- a/src/utils/misc.tsx
+++ b/src/utils/misc.tsx
@@ -216,10 +216,11 @@ export async function sleep({
  * which allows for importing into a third-party calendar application.
  */
 export function exportCoursesToCalendar(
+  term: string,
   oscar: Oscar,
   pinnedCrns: readonly string[]
 ): void {
-  const cal = ics() as ICS | undefined;
+  const cal = ics(`gt-scheduler-${term}`) as ICS | undefined;
   if (cal == null) {
     window.alert('This browser does not support calendar export');
     softError(

--- a/src/vendor/ics.js
+++ b/src/vendor/ics.js
@@ -1,6 +1,8 @@
 /* global saveAs, BlobBuilder */
 /* exported ics */
 
+import { v4 as uuidv4 } from 'uuid';
+
 const ics = (uidDomain, prodId) => {
   if (
     navigator.userAgent.indexOf('MSIE') > -1 &&
@@ -208,10 +210,11 @@ const ics = (uidDomain, prodId) => {
       }
 
       // var stamp = new Date().toISOString();
+      let uid = uuidv4().toUpperCase();
 
       let calendarEvent = [
         'BEGIN:VEVENT',
-        `UID:${calendarEvents.length}@${uidDomain}`,
+        `UID:${uid}@${uidDomain}`,
         'CLASS:PUBLIC',
         `DESCRIPTION:${description}`,
         `DTSTAMP;VALUE=DATE-TIME:${now}`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -13443,6 +13443,11 @@ uuid@^8.3.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
+
 v8-compile-cache@^2.0.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"


### PR DESCRIPTION
The events exported are now assigned a domain of `gt-scheduler` along with a random UID. Random UID generation ensures a scenario such as friends importing each other's schedules for the same semester has well-defined behaviour.

An example event can be seen here:
```
BEGIN:VEVENT
UID:03C71D76-9736-4885-92BC-2B81EDC55E8A@gt-scheduler
CLASS:PUBLIC
DESCRIPTION:Abstract Algebra II
RRULE:FREQ=WEEKLY;UNTIL=20230505T000000Z;BYDAY=MO,WE,FR
DTSTAMP;VALUE=DATE-TIME:20230114T012702
DTSTART;VALUE=DATE-TIME:20230109T123000
DTEND;VALUE=DATE-TIME:20230109T132000
LOCATION:Skiles 169
SUMMARY;LANGUAGE=en-us:MATH 4108
TRANSP:TRANSPARENT
END:VEVENT
```

closes #141

