### PR TITLE
Add "focusing" meetings on calendar, upgrade react-tooltip to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "react-overlays": "^5.1.1",
     "react-resize-panel": "^0.3.5",
     "react-scripts": "5.0.1",
-    "react-tooltip": "^4.2.10",
+    "react-tooltip": "^5.5.1",
     "react-transition-group": "^4.4.2",
     "react-virtualized": "^9.21.2",
     "s-ago": "^2.2.0",

--- a/src/components/ActionRow/index.tsx
+++ b/src/components/ActionRow/index.tsx
@@ -10,8 +10,7 @@ type FontAwesomeProps = React.ComponentProps<typeof FontAwesomeIcon>;
 export type Action = {
   icon: FontAwesomeProps['icon'];
   styling?: React.CSSProperties;
-  dataTip?: boolean;
-  dataFor?: string;
+  id?: string;
   onMouseEnter?: () => void;
   onMouseLeave?: () => void;
 } & Omit<ButtonProps, 'children'>;
@@ -41,15 +40,7 @@ export default function ActionRow({
             .flatMap((action) => (action != null ? [action] : []))
             .map(
               (
-                {
-                  icon,
-                  styling,
-                  dataTip,
-                  dataFor,
-                  onMouseEnter,
-                  onMouseLeave,
-                  ...rest
-                },
+                { icon, styling, id, onMouseEnter, onMouseLeave, ...rest },
                 i
               ) => (
                 <Button className="action" {...rest} key={i}>
@@ -57,8 +48,7 @@ export default function ActionRow({
                     fixedWidth
                     style={styling}
                     icon={icon}
-                    data-tip={dataTip}
-                    data-for={dataFor}
+                    id={id}
                     onMouseEnter={onMouseEnter}
                     onMouseLeave={onMouseLeave}
                   />

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { TooltipProvider } from 'react-tooltip';
 
 import { classes } from '../../utils/misc';
 import Feedback from '../Feedback';
@@ -29,44 +30,46 @@ export default function App(): React.ReactElement {
   return (
     <ThemeContext.Provider value={themeContextValue}>
       <AppCSSRoot>
-        <ErrorBoundary
-          fallback={(error, errorInfo): React.ReactElement => (
-            <AppSkeleton>
-              <SkeletonContent>
-                <ErrorHeader />
-                <ErrorDisplay
-                  errorDetails={
-                    <ReactErrorDetails error={error} errorInfo={errorInfo} />
-                  }
-                >
-                  <div>
-                    There was en error somewhere in the core application logic
-                    and it can&apos;t continue.
-                  </div>
-                  <div>
-                    Try refreshing the page to see if it fixes the issue.
-                  </div>
-                </ErrorDisplay>
-              </SkeletonContent>
-            </AppSkeleton>
-          )}
-        >
-          <AppNavigation>
-            {/* AppDataLoader is in charge of ensuring that there are valid values
+        <TooltipProvider>
+          <ErrorBoundary
+            fallback={(error, errorInfo): React.ReactElement => (
+              <AppSkeleton>
+                <SkeletonContent>
+                  <ErrorHeader />
+                  <ErrorDisplay
+                    errorDetails={
+                      <ReactErrorDetails error={error} errorInfo={errorInfo} />
+                    }
+                  >
+                    <div>
+                      There was en error somewhere in the core application logic
+                      and it can&apos;t continue.
+                    </div>
+                    <div>
+                      Try refreshing the page to see if it fixes the issue.
+                    </div>
+                  </ErrorDisplay>
+                </SkeletonContent>
+              </AppSkeleton>
+            )}
+          >
+            <AppNavigation>
+              {/* AppDataLoader is in charge of ensuring that there are valid values
                 for the Terms and Term contexts before rendering its children.
                 If any data is still loading,
                 then it displays an "app skeleton" with a spinner.
                 If there was an error while loading
                 then it displays an error screen. */}
-            <AppDataLoader>
-              <AppContent />
-            </AppDataLoader>
-          </AppNavigation>
-          <Feedback />
+              <AppDataLoader>
+                <AppContent />
+              </AppDataLoader>
+            </AppNavigation>
+            <Feedback />
 
-          {/* Display a popup when first visiting the site */}
-          {/* Include <InformationModal /> here */}
-        </ErrorBoundary>
+            {/* Display a popup when first visiting the site */}
+            {/* Include <InformationModal /> here */}
+          </ErrorBoundary>
+        </TooltipProvider>
       </AppCSSRoot>
     </ThemeContext.Provider>
   );

--- a/src/components/Calendar/index.tsx
+++ b/src/components/Calendar/index.tsx
@@ -6,6 +6,7 @@ import { TimeBlocks } from '..';
 import { ScheduleContext } from '../../contexts';
 import { makeSizeInfoKey, TimeBlockPosition } from '../TimeBlocks';
 import { Period } from '../../types';
+import useMedia from '../../hooks/useMedia';
 
 import './stylesheet.scss';
 
@@ -134,6 +135,14 @@ export default function Calendar({
       });
   });
 
+  // Allow the user to select a meeting, which will cause it to be highlighted
+  // and for the meeting "details" popover/tooltip to remain open.
+  type SelectedMeeting = [crn: string, meetingIndex: number, day: string];
+  const [selectedMeeting, setSelectedMeeting] =
+    React.useState<SelectedMeeting | null>(null);
+
+  const deviceHasHover = useMedia('(hover: hover)');
+
   return (
     <div
       className={classes(
@@ -173,6 +182,19 @@ export default function Calendar({
             capture={capture}
             isAutosized={isAutosized}
             sizeInfo={crnSizeInfo[crn] ?? {}}
+            selectedMeeting={
+              selectedMeeting !== null && selectedMeeting[0] === crn
+                ? [selectedMeeting[1], selectedMeeting[2]]
+                : null
+            }
+            onSelectMeeting={(meeting: [number, string] | null): void => {
+              if (meeting === null) {
+                setSelectedMeeting(null);
+              } else {
+                setSelectedMeeting([crn, meeting[0], meeting[1]]);
+              }
+            }}
+            deviceHasHover={deviceHasHover}
           />
         ))}
         {overlayCrns &&

--- a/src/components/Calendar/index.tsx
+++ b/src/components/Calendar/index.tsx
@@ -5,7 +5,7 @@ import { classes, timeToShortString } from '../../utils/misc';
 import { TimeBlocks } from '..';
 import { ScheduleContext } from '../../contexts';
 import { makeSizeInfoKey, TimeBlockPosition } from '../TimeBlocks';
-import { Meeting, Period } from '../../types';
+import { Period } from '../../types';
 import useMedia from '../../hooks/useMedia';
 
 import './stylesheet.scss';

--- a/src/components/Instructor/index.tsx
+++ b/src/components/Instructor/index.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useContext, useState } from 'react';
-import ReactTooltip from 'react-tooltip';
+import React, { useCallback, useContext, useId, useState } from 'react';
+import { Tooltip as ReactTooltip } from 'react-tooltip';
 import {
   faAngleDown,
   faAngleUp,
@@ -64,7 +64,7 @@ export default function Instructor({
     excludedCrns.includes(section.crn)
   );
 
-  const excludeTooltipId = `exclude-instructor-${name.replace(' ', '-')}`;
+  const excludeTooltipId = useId();
   return (
     <div
       className={classes(
@@ -90,8 +90,7 @@ export default function Instructor({
             : null,
           {
             icon: faBan,
-            dataTip: true,
-            dataFor: excludeTooltipId,
+            id: excludeTooltipId,
             onClick: (): void => excludeSections(sections),
           },
         ]}
@@ -101,12 +100,7 @@ export default function Instructor({
           <span className="gpa">Instructor GPA: {gpa || 'N/A'}</span>
         </div>
       </ActionRow>
-      <ReactTooltip
-        id={excludeTooltipId}
-        type="dark"
-        place="bottom"
-        effect="solid"
-      >
+      <ReactTooltip anchorId={excludeTooltipId} variant="dark" place="left">
         Exclude from Combinations
       </ReactTooltip>
       {expanded && (

--- a/src/components/Section/index.tsx
+++ b/src/components/Section/index.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useContext, useState } from 'react';
-import ReactTooltip from 'react-tooltip';
+import React, { useCallback, useContext, useId, useState } from 'react';
+import { Tooltip as ReactTooltip } from 'react-tooltip';
 import {
   faBan,
   faChair,
@@ -84,7 +84,8 @@ export default function Section({
     [pinnedCrns, excludedCrns, patchSchedule]
   );
 
-  const excludeTooltipId = `section-exclude-${section.id}`;
+  const excludeTooltipId = useId();
+  const sectionTooltipId = useId();
   return (
     <ActionRow
       label={section.id}
@@ -98,25 +99,22 @@ export default function Section({
         },
         {
           icon: faChair,
-          dataTip: true,
-          dataFor: section.id,
+          id: sectionTooltipId,
           href: `https://oscar.gatech.edu/pls/bprod/bwckschd.p_disp_detail_sched?term_in=${term}&crn_in=${section.crn}`,
         },
         {
           icon: faBan,
-          dataTip: true,
-          dataFor: excludeTooltipId,
+          id: excludeTooltipId,
           onClick: (): void => excludeSection(section),
         },
       ]}
       style={pinned ? { backgroundColor: color } : undefined}
     >
       <ReactTooltip
-        id={excludeTooltipId}
-        className="tooltip"
-        type="dark"
-        place="right"
-        effect="solid"
+        anchorId={excludeTooltipId}
+        className="popover"
+        variant="dark"
+        place="left"
       >
         Exclude from Combinations
       </ReactTooltip>
@@ -138,11 +136,10 @@ export default function Section({
         </div>
 
         <ReactTooltip
-          id={section.id}
+          anchorId={sectionTooltipId}
           className="tooltip"
-          type="dark"
-          place="right"
-          effect="solid"
+          variant="dark"
+          place="top"
           afterShow={(): void => handleHover()}
           afterHide={(): void => {
             hovering = false;

--- a/src/components/TimeBlocks/index.tsx
+++ b/src/components/TimeBlocks/index.tsx
@@ -194,7 +194,7 @@ function MeetingDayBlock({
           canBeTabFocused
             ? (e: React.FocusEvent): void => {
                 e.stopPropagation();
-                onSelect(true);
+                setIsHovered(true);
               }
             : undefined
         }
@@ -202,7 +202,7 @@ function MeetingDayBlock({
           canBeTabFocused
             ? (e: React.FocusEvent): void => {
                 e.stopPropagation();
-                onSelect(false);
+                setIsHovered(false);
               }
             : undefined
         }

--- a/src/components/TimeBlocks/index.tsx
+++ b/src/components/TimeBlocks/index.tsx
@@ -1,10 +1,12 @@
-import React, { useContext } from 'react';
-import ReactTooltip from 'react-tooltip';
+import React, { useContext, useId } from 'react';
+import { Tooltip as ReactTooltip } from 'react-tooltip';
+import { useRootClose } from 'react-overlays';
 
 import { classes, getContentClassName, periodToString } from '../../utils/misc';
 import { CLOSE, OPEN, DAYS } from '../../constants';
 import { ScheduleContext } from '../../contexts';
-import { Period } from '../../types';
+import { Meeting, Period } from '../../types';
+import { Section } from '../../data/beans';
 
 import './stylesheet.scss';
 
@@ -25,6 +27,20 @@ export type TimeBlocksProps = {
   preview: boolean;
   isAutosized: boolean;
   sizeInfo: SizeInfo;
+  /**
+   * Passing through this prop to skip subscribing to a media query per
+   * TimeBlocks component instance:
+   */
+  deviceHasHover?: boolean;
+  /**
+   * The index of the meeting and day to highlight. This will also cause the
+   * details popover to remain open. If null/undefined, no meeting is
+   * highlighted.
+   */
+  selectedMeeting?: [meetingIndex: number, day: string] | null;
+  onSelectMeeting?: (
+    meeting: [meetingIndex: number, day: string] | null
+  ) => void;
 };
 
 export function makeSizeInfoKey(period: Period): string {
@@ -39,6 +55,9 @@ export default function TimeBlocks({
   capture,
   isAutosized,
   sizeInfo,
+  deviceHasHover = true,
+  selectedMeeting,
+  onSelectMeeting,
 }: TimeBlocksProps): React.ReactElement | null {
   const [{ oscar, colorMap }] = useContext(ScheduleContext);
 
@@ -46,7 +65,6 @@ export default function TimeBlocks({
   if (section == null) return null;
 
   const color = colorMap[section.course.id];
-  const contentClassName = getContentClassName(color);
 
   return (
     <div
@@ -69,80 +87,229 @@ export default function TimeBlocks({
           if (sizeInfoPeriodDay == null) return;
 
           return (
-            <div
-              className={classes('meeting', contentClassName, 'default', day)}
-              key={[i, day].join('-')}
-              style={{
-                top: `${((period.start - OPEN) / (CLOSE - OPEN)) * 100}%`,
-                height: `${
-                  ((period.end - period.start) / (CLOSE - OPEN)) * 100
-                }%`,
-                width: `${20 / sizeInfoPeriodDay.rowSize}%`,
-                left: `${
-                  DAYS.indexOf(day) * 20 +
-                  sizeInfoPeriodDay.rowIndex * (20 / sizeInfoPeriodDay.rowSize)
-                }%`,
-                backgroundColor: color,
+            <MeetingDayBlock
+              color={color}
+              day={day}
+              period={period}
+              section={section}
+              meeting={meeting}
+              sizeInfo={sizeInfoPeriodDay}
+              includeDetailsPopover={!isAutosized}
+              includeContent={!preview}
+              isSelected={
+                selectedMeeting != null &&
+                selectedMeeting[0] === i &&
+                selectedMeeting[1] === day
+              }
+              onSelect={(newIsSelected: boolean): void => {
+                if (onSelectMeeting == null) return;
+                if (newIsSelected) {
+                  onSelectMeeting([i, day]);
+                } else {
+                  onSelectMeeting(null);
+                }
               }}
-              data-tip
-              data-for={crn}
-            >
-              {!preview && (
-                <div className="meeting-wrapper">
-                  <div className="ids">
-                    <span className="course-id">{section.course.id}</span>
-                    <span className="section-id">&nbsp;{section.id}</span>
-                  </div>
-                  <span className="period">{periodToString(period)}</span>
-                  <span className="where">{meeting.where}</span>
-                  <span className="instructors">
-                    {meeting.instructors.join(', ')}
-                  </span>
-                </div>
-              )}
-            </div>
+              key={`${day}-${sizeInfoKey}`}
+              deviceHasHover={deviceHasHover}
+            />
           );
         });
       })}
+    </div>
+  );
+}
 
-      {!isAutosized && (
+type MeetingDayBlockProps = {
+  color: string | undefined;
+  day: string;
+  period: Period;
+  section: Section;
+  meeting: Meeting;
+  sizeInfo: TimeBlockPosition;
+  includeDetailsPopover: boolean;
+  includeContent: boolean;
+  isSelected: boolean;
+  onSelect: (newIsSelected: boolean) => void;
+  deviceHasHover: boolean;
+};
+
+function MeetingDayBlock({
+  color,
+  day,
+  period,
+  section,
+  meeting,
+  sizeInfo,
+  includeDetailsPopover,
+  includeContent,
+  isSelected,
+  onSelect,
+  deviceHasHover,
+}: MeetingDayBlockProps): React.ReactElement {
+  const tooltipId = useId();
+  const contentClassName = getContentClassName(color);
+  const outerRef = React.useRef<HTMLDivElement>(null);
+  const handleRootClose = (): void => {
+    if (isSelected) onSelect(false);
+  };
+  useRootClose(outerRef, handleRootClose, {
+    disabled: !isSelected,
+  });
+
+  const [isHovered, setIsHovered] = React.useState(false);
+  return (
+    <div ref={outerRef}>
+      <div
+        className={classes(
+          'meeting',
+          contentClassName,
+          'default',
+          day,
+          isSelected && 'meeting--selected'
+        )}
+        style={{
+          top: `${((period.start - OPEN) / (CLOSE - OPEN)) * 100}%`,
+          height: `${((period.end - period.start) / (CLOSE - OPEN)) * 100}%`,
+          width: `${20 / sizeInfo.rowSize}%`,
+          left: `${
+            DAYS.indexOf(day) * 20 + sizeInfo.rowIndex * (20 / sizeInfo.rowSize)
+          }%`,
+          ...({
+            '--meeting-color': color,
+          } as React.CSSProperties),
+        }}
+        id={tooltipId}
+        onClick={(e: React.MouseEvent): void => {
+          e.stopPropagation();
+          onSelect(!isSelected);
+        }}
+        onFocus={(e: React.FocusEvent): void => {
+          e.stopPropagation();
+          onSelect(true);
+        }}
+        onBlur={(e: React.FocusEvent): void => {
+          e.stopPropagation();
+          onSelect(false);
+        }}
+      >
+        {includeContent && (
+          <div className="meeting-wrapper">
+            <div className="ids">
+              <span className="course-id">{section.course.id}</span>
+              <span className="section-id">&nbsp;{section.id}</span>
+            </div>
+            <span className="period">{periodToString(period)}</span>
+            <span className="where">{meeting.where}</span>
+            <span className="instructors">
+              {meeting.instructors.join(', ')}
+            </span>
+          </div>
+        )}
+      </div>
+      {/* Include a details popover that can be opened by either:
+      - hovering over the meeting, on devices with hover. This opens a
+        "preview", which has less opacity.
+      - clicking, tapping, or focusing on the meeting. This "selects" it,
+        shows the popover with more opacity, and adds a selection 'halo' around
+        the meeting block itself. */}
+      {includeDetailsPopover && (
         <ReactTooltip
-          id={crn}
+          anchorId={tooltipId}
           className="tooltip"
-          type="dark"
+          variant="dark"
           place="top"
-          effect="solid"
+          clickable
+          isOpen={isSelected || isHovered}
+          setIsOpen={setIsHovered}
+          delayShow={20}
+          delayHide={100}
+          // HACK: ReactTooltip can't handle changing the `events` prop, so we
+          // need to force a remount when the `deviceHasHover` prop changes.
+          // This probably won't happen often in the wild, but it's noticeable
+          // when debugging in devtools:
+          key={deviceHasHover ? 0 : 1}
+          // Disable the hover event if the device doesn't support it, since
+          // clicks are handled separately and present a better UX.
+          // Without this, the hover event will be triggered in the same way as
+          // clicks, which is redundant. Moreover, upon loosing focus on mobile,
+          // the "delayHide" causes the tooltip to remain open for a small
+          // amount of time which is noticeable, especially because the
+          // "selected" styles stop applying while the tooltip is still open.
+          events={deviceHasHover ? ['hover'] : []}
         >
-          <table>
-            <tbody>
-              <tr>
-                <td>
-                  <b>Course Name</b>
-                </td>
-                <td>{section.course.title}</td>
-              </tr>
-              <tr>
-                <td>
-                  <b>Delivery Type</b>
-                </td>
-                <td>{section.deliveryMode}</td>
-              </tr>
-              <tr>
-                <td>
-                  <b>Course Number</b>
-                </td>
-                <td>{section.crn}</td>
-              </tr>
-              <tr>
-                <td>
-                  <b>Credit Hours</b>
-                </td>
-                <td>{section.credits}</td>
-              </tr>
-            </tbody>
-          </table>
+          <DetailsPopoverContent
+            title={section.course.title}
+            instructors={meeting.instructors}
+            location={meeting.where}
+            crn={section.crn}
+            credits={section.credits}
+            deliveryMode={section.deliveryMode ?? null}
+          />
         </ReactTooltip>
       )}
     </div>
+  );
+}
+
+type DetailsPopoverContentProps = {
+  title: string;
+  instructors: string[];
+  location: string;
+  crn: string;
+  credits: number;
+  deliveryMode: string | null;
+};
+
+function DetailsPopoverContent({
+  title,
+  instructors,
+  location,
+  crn,
+  credits,
+  deliveryMode,
+}: DetailsPopoverContentProps): React.ReactElement {
+  return (
+    <table>
+      <tbody>
+        <tr>
+          <td>
+            <b>Course Name</b>
+          </td>
+          <td>{title}</td>
+        </tr>
+        <tr>
+          <td>
+            <b>Instructors</b>
+          </td>
+          <td>{instructors.join(', ')}</td>
+        </tr>
+        <tr>
+          <td>
+            <b>Location</b>
+          </td>
+          <td>{location}</td>
+        </tr>
+        <tr>
+          <td>
+            <b>CRN</b>
+          </td>
+          <td>{crn}</td>
+        </tr>
+        <tr>
+          <td>
+            <b>Credit Hours</b>
+          </td>
+          <td>{credits}</td>
+        </tr>
+        {deliveryMode && (
+          <tr>
+            <td>
+              <b>Delivery Type</b>
+            </td>
+            <td>{deliveryMode}</td>
+          </tr>
+        )}
+      </tbody>
+    </table>
   );
 }

--- a/src/components/TimeBlocks/stylesheet.scss
+++ b/src/components/TimeBlocks/stylesheet.scss
@@ -63,7 +63,7 @@
     
     &--selected {
       &::after {
-        opacity: 0.3;
+        opacity: 0.5;
       }
 
       & + .tooltip {

--- a/src/components/TimeBlocks/stylesheet.scss
+++ b/src/components/TimeBlocks/stylesheet.scss
@@ -37,6 +37,8 @@
     background-color: var(--meeting-color, $color-neutral);
     outline: none;
     border: none;
+    text-align: left;
+    padding: 0;
 
     &:focus {
       // Remove the default focus style, since selecting the meeting

--- a/src/components/TimeBlocks/stylesheet.scss
+++ b/src/components/TimeBlocks/stylesheet.scss
@@ -35,6 +35,14 @@
     flex-direction: column;
     align-items: stretch;
     background-color: var(--meeting-color, $color-neutral);
+    outline: none;
+    border: none;
+
+    &:focus {
+      // Remove the default focus style, since selecting the meeting
+      // adds its own focus style:
+      outline: none;
+    }
     
     // Add a box-shadow border to the meeting block when it is highlighted
     &::after {

--- a/src/components/TimeBlocks/stylesheet.scss
+++ b/src/components/TimeBlocks/stylesheet.scss
@@ -7,13 +7,11 @@
     }
   }
 
-  :hover {
-    cursor: pointer;
-  }
-
   .tooltip {
-    opacity: 0.95;
+    opacity: 0.85;
     border-radius: 8px;
+    z-index: 2;
+    cursor: unset;
   }
 
   tr {
@@ -36,6 +34,36 @@
     display: flex;
     flex-direction: column;
     align-items: stretch;
+    background-color: var(--meeting-color, $color-neutral);
+    
+    // Add a box-shadow border to the meeting block when it is highlighted
+    &::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      opacity: 0;
+      z-index: -1;
+      box-shadow: 0 0 0 6px var(--meeting-color, $color-neutral);
+      border-radius: 2px;
+      transition: opacity 0.2s ease-in-out;
+    }
+    
+    &--selected {
+      &::after {
+        opacity: 0.3;
+      }
+
+      & + .tooltip {
+        opacity: 0.95;
+      }
+    }
+
+    :hover {
+      cursor: pointer;
+    }
 
     .meeting-wrapper {
       flex: 1;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import App from './components/App';
 import { ErrorWithFields } from './log';
 
 import 'normalize.css';
+import 'react-tooltip/dist/react-tooltip.css';
 import './stylesheet.scss';
 
 // Only initialize sentry on production

--- a/yarn.lock
+++ b/yarn.lock
@@ -1475,6 +1475,18 @@
   resolved "https://registry.yarnpkg.com/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.5.1.tgz#a64d1af3c62e3bb89576ec58af880980a562bf4e"
   integrity sha512-dZMzN0uAjwJXWYYAcnxIwXqRTZw3o14hGe7O6uhwjD1ZQWPVYA5lASgnNskEBra0knVBsOXB4KXg+HnlKewN/A==
 
+"@floating-ui/core@^1.0.5":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.1.0.tgz#0a1dee4bbce87ff71602625d33f711cafd8afc08"
+  integrity sha512-zbsLwtnHo84w1Kc8rScAo5GMk1GdecSlrflIbfnEBJwvTSj1SL6kkOYV+nHraMCPEy+RNZZUaZyL8JosDGCtGQ==
+
+"@floating-ui/dom@^1.0.4":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.1.0.tgz#29fea1344fdef15b6ba270a733d20b7134fee5c2"
+  integrity sha512-TSogMPVxbRe77QCj1dt8NmRiJasPvuc+eT5jnJ6YpLqgOD2zXc5UA3S1qwybN+GVCDNdKfpKy1oj8RpzLJvh6A==
+  dependencies:
+    "@floating-ui/core" "^1.0.5"
+
 "@fortawesome/fontawesome-common-types@6.2.1":
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.2.1.tgz#411e02a820744d3f7e0d8d9df9d82b471beaa073"
@@ -3871,7 +3883,7 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
 
-classnames@^2.2.6:
+classnames@^2.2.6, classnames@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
   integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
@@ -9772,13 +9784,13 @@ react-scripts@5.0.1:
   optionalDependencies:
     fsevents "^2.3.2"
 
-react-tooltip@^4.2.10:
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-4.5.1.tgz#77eccccdf16adec804132e558ec20ca5783b866a"
-  integrity sha512-Zo+CSFUGXar1uV+bgXFFDe7VeS2iByeIp5rTgTcc2HqtuOS5D76QapejNNfx320MCY91TlhTQat36KGFTqgcvw==
+react-tooltip@^5.5.1:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-5.5.1.tgz#3f68c42e5625123ed719dac15e9fc66e4159b565"
+  integrity sha512-mx8iL4DDYUdPhN2XbcF4koHyuOOs7/gFXq0TBVfLnRWigzfll7AArMe3yUDipvowW/OASwzdGVgoBECVSMdtBA==
   dependencies:
-    prop-types "^15.8.1"
-    uuid "^7.0.3"
+    "@floating-ui/dom" "^1.0.4"
+    classnames "^2.3.2"
 
 react-transition-group@^4.4.2:
   version "4.4.5"
@@ -11406,11 +11418,6 @@ uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-
-uuid@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
-  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
 uuid@^8.3.2:
   version "8.3.2"


### PR DESCRIPTION
### Summary

This PR implements a way to "focus" meeting blocks on the central calendar view, which shows the "details" popover persistently:

#### Desktop demo

![desktop](https://user-images.githubusercontent.com/26242455/213067276-04192138-e615-47b9-964e-bd2811a5ec05.gif)

#### Mobile demo

![mobile](https://user-images.githubusercontent.com/26242455/213067277-897d3a5d-e56a-4e76-9f87-536175d6fcf6.gif)

This is in addition to the previous behavior of showing the details popover when hovering over a meeting (on desktop). This PR builds on that functionality to:
- allow text to be copied/selected in the popover
- make the mobile experience better, since the courses can be intentionally focused by tapping on/away from them
- make the details on the calendar accessible to keyboard users

#### Upgrading to `react-tooltip` v5

This PR also involved upgrading to `react-tooltip` v5, which contains advanced features used in the implementation of the PR. This was made possible now that the project is on React v18 (after #143).

### Motivation

Fixes #133 by allowing the location and professor to be viewed on mobile via the details popover.

Also fixes #132 