### PR TITLE
Abbreviate meeting locations on TimeBlock components

### DIFF
--- a/src/components/TimeBlocks/index.tsx
+++ b/src/components/TimeBlocks/index.tsx
@@ -2,7 +2,12 @@ import React, { useContext, useId } from 'react';
 import { Tooltip as ReactTooltip } from 'react-tooltip';
 import { useRootClose } from 'react-overlays';
 
-import { classes, getContentClassName, periodToString } from '../../utils/misc';
+import {
+  abbreviateLocation,
+  classes,
+  getContentClassName,
+  periodToString,
+} from '../../utils/misc';
 import { CLOSE, OPEN, DAYS } from '../../constants';
 import { ScheduleContext } from '../../contexts';
 import { Meeting, Period } from '../../types';
@@ -215,7 +220,7 @@ function MeetingDayBlock({
               <span className="section-id">&nbsp;{section.id}</span>
             </div>
             <span className="period">{periodToString(period)}</span>
-            <span className="where">{meeting.where}</span>
+            <span className="where">{abbreviateLocation(meeting.where)}</span>
             <span className="instructors">
               {meeting.instructors.join(', ')}
             </span>

--- a/src/utils/misc.tsx
+++ b/src/utils/misc.tsx
@@ -373,3 +373,52 @@ export function lexicographicCompare(a: string, b: string): number {
 
   return -1;
 }
+
+// Edit this map to control how locations are abbreviated.
+// Prefer adding new entries to this map over changing the location strings,
+// since old schedules can still be opened in the app.
+//
+// When adding new entries, consider also updating the crawler's coordinate
+// mapping in https://github.com/gt-scheduler/crawler/blob/main/src/steps/parse.ts
+// (search for `courseLocations`).
+//
+// Initial locations were loosely based on:
+// https://github.com/gt-scheduler/crawler/blob/main/src/steps/parse.ts
+const LOCATION_ABBREVIATIONS: Record<string, string> = {
+  '760 Spring St NW': '760 Spring St',
+  '760 Spring Street': '760 Spring St',
+  'Clough Commons': 'CULC',
+  'Clough UG Learning Commons': 'CULC',
+  'Coll of Computing': 'CCB',
+  'College of Computing': 'CCB',
+  'D. M. Smith': 'DM Smith',
+  'D.M. Smith': 'DM Smith',
+  'Engr Science & Mech': 'ESM',
+  'Engineering Sci and Mechanics': 'ESM',
+  'Ford Environmental Sci & Tech': 'ES&T',
+  'Howey (Physics)': 'Howey',
+  'Howey Physics': 'Howey',
+  'Instr Center': 'IC',
+  'Instructional Center': 'IC',
+  'J. Erskine Love Manufacturing': 'Love (MRDC II)',
+  'Klaus Advanced Computing': 'Klaus',
+  'Manufacture Rel Discip Complex': 'MRDC',
+  'Molecular Sciences & Engr': 'MoSE',
+  'Molecular Sciences & Engineering': 'MoSE',
+  'Paper Tricentennial': 'Paper',
+  'Scheller College of Business': 'Scheller',
+  'Sustainable Education': 'SEB',
+  'U A Whitaker Biomedical Engr': 'Whitaker',
+  'West Village Dining Commons': 'West Village',
+};
+
+export function abbreviateLocation(location: string): string {
+  for (const [full, abbrev] of Object.entries(LOCATION_ABBREVIATIONS)) {
+    if (location.startsWith(full)) {
+      const withoutFull = location.substring(full.length).trim();
+      return `${abbrev} ${withoutFull}`;
+    }
+  }
+
+  return location;
+}


### PR DESCRIPTION
### Summary

Abbreviates meeting locations in the content of `<TimeBlock>` components. This does not affect any other uses of location, and the full location string is still visible when hovering/focusing the time block.

![localhost_3000_](https://user-images.githubusercontent.com/26242455/215223902-9bb06ee0-fa7e-439c-a01b-205a8bb2c3df.png)


### Motivation

Many of the location strings are excessively long, so this helps them display within the small boxes on the calendar without getting cut off (since the text in the content of `<TimeBlock>`'s is restricted to a single line).

See https://github.com/gt-scheduler/website/pull/144#issuecomment-1387379887