### PR TITLE
Add Functionality to Invitation Modal

### DIFF
--- a/src/components/AppDataLoader/index.tsx
+++ b/src/components/AppDataLoader/index.tsx
@@ -286,12 +286,17 @@ function ContextProvider({
   }, [termScheduleData.versions]);
 
   // Get all version-related actions
-  const { addNewVersion, deleteVersion, renameVersion, cloneVersion } =
-    useVersionActions({
-      updateTermScheduleData,
-      setVersion,
-      currentVersion,
-    });
+  const {
+    addNewVersion,
+    deleteVersion,
+    renameVersion,
+    cloneVersion,
+    updateFriends,
+  } = useVersionActions({
+    updateTermScheduleData,
+    setVersion,
+    currentVersion,
+  });
 
   // Memoize the context values so that they are stable
   const scheduleContextValue = useMemo<ScheduleContextValue>(
@@ -301,6 +306,7 @@ function ContextProvider({
         oscar,
         currentVersion,
         allVersionNames,
+        currentFriends: scheduleVersion.friends,
         ...castDraft(scheduleVersion.schedule),
       },
       {
@@ -310,6 +316,7 @@ function ContextProvider({
         setCurrentVersion: setVersion,
         addNewVersion,
         deleteVersion,
+        updateFriends,
         renameVersion,
         cloneVersion,
       },
@@ -319,12 +326,14 @@ function ContextProvider({
       oscar,
       currentVersion,
       allVersionNames,
+      scheduleVersion.friends,
       scheduleVersion.schedule,
       setTerm,
       patchSchedule,
       updateSchedule,
       setVersion,
       addNewVersion,
+      updateFriends,
       deleteVersion,
       renameVersion,
       cloneVersion,

--- a/src/components/AppDataLoader/stages.tsx
+++ b/src/components/AppDataLoader/stages.tsx
@@ -256,7 +256,6 @@ export function StageLoadRawScheduleDataFromFirebase({
   children,
 }: StageLoadRawScheduleDataFromFirebaseProps): React.ReactElement {
   const loadingState = useRawScheduleDataFromFirebase(accountState);
-
   if (loadingState.type !== 'loaded') {
     return (
       <AppSkeleton {...skeletonProps}>

--- a/src/components/HeaderActionBar/index.tsx
+++ b/src/components/HeaderActionBar/index.tsx
@@ -88,13 +88,15 @@ export default function HeaderActionBar({
       onClick: onCopyCrns,
     });
   }
-  exportActions.push({
-    label: 'Share Schedule',
-    icon: faShare,
-    onClick: (): void => {
-      setInvitationOpen(true);
-    },
-  });
+  if (accountState.type === 'signedIn') {
+    exportActions.push({
+      label: 'Share Schedule',
+      icon: faShare,
+      onClick: (): void => {
+        setInvitationOpen(true);
+      },
+    });
+  }
 
   // On small mobile screens and on large desktop,
   // left-anchor the "Export" dropdown.

--- a/src/components/InviteBackLink/index.tsx
+++ b/src/components/InviteBackLink/index.tsx
@@ -7,15 +7,17 @@ import { CLOUD_FUNCTION_BASE_URL } from '../../constants';
 const handleInvite = async (inviteId: string | undefined): Promise<void> =>
   // The link should be changed to prod link, or we can choose the link based
   // on environment
-  axios.post(
-    `${CLOUD_FUNCTION_BASE_URL}/handleFriendInvitation`,
-    { inviteId },
-    {
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    }
-  );
+  axios
+    .post(
+      `http://127.0.0.1:5001/gt-scheduler-web-dev/us-central1/handleFriendInvitation`,
+      { inviteId }
+    )
+    .then((res) => {
+      console.log(res);
+    })
+    .catch((err) => {
+      console.error(err);
+    });
 
 export default function InviteBackLink(): React.ReactElement {
   const navigate = useNavigate();

--- a/src/contexts/account.ts
+++ b/src/contexts/account.ts
@@ -7,6 +7,7 @@ export type SignedOut = {
 export type SignedIn = {
   type: 'signedIn';
   signOut: () => void;
+  getToken: () => Promise<string | void>;
   name: string | null;
   provider: string | null;
   email: string | null;

--- a/src/contexts/schedule.ts
+++ b/src/contexts/schedule.ts
@@ -3,12 +3,13 @@ import { Draft, Immutable } from 'immer';
 
 import { Oscar } from '../data/beans';
 import { EMPTY_OSCAR } from '../data/beans/Oscar';
-import { defaultSchedule, Schedule } from '../data/types';
+import { defaultSchedule, FriendShareData, Schedule } from '../data/types';
 import { ErrorWithFields } from '../log';
 
 type ExtraData = {
   term: string;
   currentVersion: string;
+  currentFriends: Record<string, FriendShareData>;
   allVersionNames: { id: string; name: string }[];
   // `oscar` is included below as a separate type
 };
@@ -28,6 +29,10 @@ export type ScheduleContextSetters = {
   deleteVersion: (id: string) => void;
   renameVersion: (id: string, newName: string) => void;
   cloneVersion: (id: string, newName: string) => void;
+  updateFriends: (
+    versionId: string,
+    newFriends: Record<string, FriendShareData>
+  ) => void;
 };
 export type ScheduleContextValue = [
   ScheduleContextData,
@@ -37,6 +42,7 @@ export const ScheduleContext = React.createContext<ScheduleContextValue>([
   {
     term: '',
     currentVersion: '',
+    currentFriends: {},
     allVersionNames: [],
     oscar: EMPTY_OSCAR,
     ...defaultSchedule,
@@ -68,6 +74,18 @@ export const ScheduleContext = React.createContext<ScheduleContextValue>([
         message: 'empty ScheduleContext.setCurrentVersion value being used',
         fields: {
           next,
+        },
+      });
+    },
+    updateFriends: (
+      versionId: string,
+      newFriends: Record<string, FriendShareData>
+    ): void => {
+      throw new ErrorWithFields({
+        message: 'empty ScheduleContext.deleteFriendRecord value being used',
+        fields: {
+          versionId,
+          newFriends,
         },
       });
     },

--- a/src/data/hooks/useExtractScheduleVersion.ts
+++ b/src/data/hooks/useExtractScheduleVersion.ts
@@ -62,6 +62,7 @@ export default function useExtractScheduleVersion({
             const id = generateScheduleVersionId();
             draft.versions[id] = {
               name: 'Primary',
+              friends: {},
               createdAt: new Date().toISOString(),
               schedule: castDraft(defaultSchedule),
             };

--- a/src/data/hooks/useFirebaseAuth.ts
+++ b/src/data/hooks/useFirebaseAuth.ts
@@ -32,6 +32,26 @@ export default function useFirebaseAuth(): LoadingState<AccountContextValue> {
             name: user.displayName,
             email: user.email,
             id: user.uid,
+            getToken: (): Promise<string | void> => {
+              if (firebase.auth().currentUser === null) {
+                return Promise.reject(
+                  new ErrorWithFields({
+                    message: 'firebase.auth().currentUser is null',
+                  })
+                );
+              }
+              return firebase
+                .auth()
+                .currentUser!.getIdToken()
+                .catch((err) => {
+                  softError(
+                    new ErrorWithFields({
+                      message: 'call to firebase.auth().getIdToken() failed',
+                      source: err,
+                    })
+                  );
+                });
+            },
             provider,
             signOut: () => {
               firebase

--- a/src/data/hooks/useMigrateScheduleData.test.ts
+++ b/src/data/hooks/useMigrateScheduleData.test.ts
@@ -83,6 +83,7 @@ describe('useMigrateScheduleData', () => {
               name: 'Primary',
               // January 1, 1970 at 0 seconds
               createdAt: '1970-01-01T00:00:00.000Z',
+              friends: {},
               schedule: {
                 desiredCourses: ['CS 1100', 'CS 1331'],
                 pinnedCrns: [
@@ -140,6 +141,7 @@ describe('useMigrateScheduleData', () => {
                 sv_48RC7kqO7YDiBK66qXOd: {
                   name: 'Primary',
                   createdAt: '2021-09-16T00:00:46.191Z',
+                  friends: {},
                   schedule: {
                     desiredCourses: ['CS 1100', 'CS 1331'],
                     pinnedCrns: [

--- a/src/data/migrations/2to3.ts
+++ b/src/data/migrations/2to3.ts
@@ -37,6 +37,7 @@ export default function migrate2To3(
       const version3ScheduleVersion: Version3ScheduleVersion = {
         name: version2ScheduleVersion.name,
         createdAt: version2ScheduleVersion.createdAt,
+        friends: {},
         schedule: {
           ...version2ScheduleVersion.schedule,
           ...newFields,

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -134,8 +134,14 @@ export interface Version3TermScheduleData {
 
 export interface Version3ScheduleVersion {
   name: string;
+  friends: Record<string, FriendShareData>;
   createdAt: string;
   schedule: Version3Schedule;
+}
+
+export interface FriendShareData {
+  status: 'Pending' | 'Accepted';
+  email: string;
 }
 
 export interface Version3Schedule {


### PR DESCRIPTION
### Summary

Resolves #173 

Users can now send invitations to friends from the share schedule popup. Added new variables to ScheduleContext to update and friend data. Added checks to make sure only signed in users can open popup.  Update cloud functions (https://github.com/gt-scheduler/firebase-conf/pull/3) to alter create and handle invitation behavior. Fixed cloud functions to account for requests made from both fetch and axios. 

### Checklist
- [x] `ScheduleData` is updated to include the list of invited friends and the status of the invitation.
   - [x] `migrateScheduleData` must be updated along with any related tests.
- [ ] Autocomplete displays emails of recently invited friends from the last 3 semesters.
- [ ] Search results are displayed based on what the user has typed in.
- [x] Emails are sent and feedback is displayed to the user appropriately.
- [x] Status of invitation is updated appropriately.
- [x] List of invited friends is displayed appropriately.


### How to Test
Run firebase cloud function emulator from the firebase-conf repository and then try inviting users from the fronted.

###Note
Did not implement recently invited friends feature yet because of the backend overhead. There is a piece of commented out code in InvitationModal which I could not resolve lint issues for. 
