### PR TITLE
Update seating info parser for migration

### DIFF
--- a/src/data/beans/Section.ts
+++ b/src/data/beans/Section.ts
@@ -170,11 +170,10 @@ export default class Section {
           const $ = cheerio.load(response.data);
 
           const availabilities = $('span').not('.status-bold');
-
           this.seating = [
             [
-              parseInt(availabilities.eq(0).text(), 10),
               parseInt(availabilities.eq(1).text(), 10),
+              parseInt(availabilities.eq(0).text(), 10),
               parseInt(availabilities.eq(3).text(), 10),
               parseInt(availabilities.eq(4).text(), 10),
             ],

--- a/src/data/beans/Section.ts
+++ b/src/data/beans/Section.ts
@@ -168,15 +168,15 @@ export default class Section {
           }
 
           const $ = cheerio.load(response.data);
-          const availabilityTable = $('.datadisplaytable .datadisplaytable');
-          const tableRow = availabilityTable.find('tr');
+
+          const availabilities = $('span').not('.status-bold');
 
           this.seating = [
             [
-              parseInt(tableRow.eq(1).children('td').first().text(), 10),
-              parseInt(tableRow.eq(1).children('td').eq(1).text(), 10),
-              parseInt(tableRow.eq(2).children('td').first().text(), 10),
-              parseInt(tableRow.eq(2).children('td').eq(1).text(), 10),
+              parseInt(availabilities.eq(0).text(), 10),
+              parseInt(availabilities.eq(1).text(), 10),
+              parseInt(availabilities.eq(3).text(), 10),
+              parseInt(availabilities.eq(4).text(), 10),
             ],
             currDate,
           ];


### PR DESCRIPTION
### Summary

Resolves https://github.com/gt-scheduler/crawler-v2/issues/5

<!-- What does this PR change and why? Discuss any breaking changes. -->
Updates seating info parser to account for crawler migration. PR should be merged with https://github.com/gt-scheduler/backend/pull/11

### How to Test
<!-- Describe how to test your code. -->
- Host backend locally, change BACKEND_URL to http://localhost:[PORT]
- Run frontend, check enrollment info on courses
