### PR TITLE
Disable Recurring Events Outside Timeframe

### DIFF
--- a/src/components/EventAdd/index.tsx
+++ b/src/components/EventAdd/index.tsx
@@ -76,7 +76,7 @@ export default function EventAdd({
       if (parsedEnd !== -1 && parsedEnd <= parsedStart) {
         setError('Start time must be before end time.');
       } else if (parsedStart < 480 || parsedEnd > 1260) {
-        setError('Start and end time must be between 08:00 AM and 09:00 PM.');
+        setError('Event must be between 08:00 AM and 10:00 PM.');
       }
     },
     [end, parseTime]
@@ -94,7 +94,7 @@ export default function EventAdd({
       if (parsedStart !== -1 && parsedEnd <= parsedStart) {
         setError('Start time must be before end time.');
       } else if (parsedStart < 480 || parsedEnd > 1260) {
-        setError('Start and end time must be between 08:00 AM and 09:00 PM.');
+        setError('Event must be between 08:00 AM and 10:00 PM.');
       }
     },
     [start, parseTime]

--- a/src/components/EventAdd/index.tsx
+++ b/src/components/EventAdd/index.tsx
@@ -236,8 +236,6 @@ export default function EventAdd({
               <td className="input">
                 <input
                   type="time"
-                  min="08:00"
-                  max="21:00"
                   value={start}
                   onChange={handleStartChange}
                   onKeyDown={handleKeyDown}
@@ -253,8 +251,6 @@ export default function EventAdd({
               <td className="input">
                 <input
                   type="time"
-                  min="08:00"
-                  max="21:00"
                   value={end}
                   onChange={handleEndChange}
                   onKeyDown={handleKeyDown}

--- a/src/components/EventAdd/index.tsx
+++ b/src/components/EventAdd/index.tsx
@@ -75,6 +75,8 @@ export default function EventAdd({
       const parsedEnd = parseTime(end);
       if (parsedEnd !== -1 && parsedEnd <= parsedStart) {
         setError('Start time must be before end time.');
+      } else if (parsedStart < 480 || parsedEnd > 1260) {
+        setError('Start and end time must be between 08:00 AM and 09:00 PM.');
       }
     },
     [end, parseTime]
@@ -91,6 +93,8 @@ export default function EventAdd({
       const parsedEnd = parseTime(newEnd);
       if (parsedStart !== -1 && parsedEnd <= parsedStart) {
         setError('Start time must be before end time.');
+      } else if (parsedStart < 480 || parsedEnd > 1260) {
+        setError('Start and end time must be between 08:00 AM and 09:00 PM.');
       }
     },
     [start, parseTime]
@@ -232,6 +236,8 @@ export default function EventAdd({
               <td className="input">
                 <input
                   type="time"
+                  min="08:00"
+                  max="21:00"
                   value={start}
                   onChange={handleStartChange}
                   onKeyDown={handleKeyDown}
@@ -247,6 +253,8 @@ export default function EventAdd({
               <td className="input">
                 <input
                   type="time"
+                  min="08:00"
+                  max="21:00"
                   value={end}
                   onChange={handleEndChange}
                   onKeyDown={handleKeyDown}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,7 @@
 import { firebaseConfig } from './data/firebase';
 
 const OPEN = 8 * 60;
-const CLOSE = 21 * 60;
+const CLOSE = 22 * 60;
 const DAYS = ['M', 'T', 'W', 'R', 'F'];
 
 const PNG_SCALE_FACTOR = 2;

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -1,4 +1,4 @@
-$calendar-height: 840px;
+$calendar-height: 920px;
 $calendar-width: 720px;
 $time-width: 48px;
 $day-height: 40px;


### PR DESCRIPTION
### Summary

Resolves #183

Bugfix for events outside of the calendar's timeframe. Since GTS also has a bug for classes that end at 9:15pm being displayed outside of the calendar, this PR also extends the calendar timeframe to 10pm. With these changes, all events now have to be between 8am and 10pm.

### Checklist

- [x] When the recurring event block start/end time is before 8am or after 10pm an error message should be generated. 
    - [x] When a user inputs a custom block start time before 8am and clicks "add", an error message of "Event start time cannot be before 8am" is generated in red below the time input field.
    - [x] When a user inputs a custom block start time before 10pm and clicks "add", an error message of "Event end time cannot be past 10pm" is generated in red below the time input field.
- [x] When the recurring event block start/end time is before 8am or after 10pm, the recurring event block should:
    - [x] NOT be created as a block
    - [x] NOT be stored 
    - [x] NOT be displayed on the scheduler

### How to Test
Try to add a new event outside of timeframe.
