### PR TITLE
Add tooltips

### DIFF
--- a/src/components/ActionRow/index.tsx
+++ b/src/components/ActionRow/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Tooltip as ReactTooltip } from 'react-tooltip';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { classes } from '../../utils/misc';
@@ -11,6 +12,7 @@ export type Action = {
   icon: FontAwesomeProps['icon'];
   styling?: React.CSSProperties;
   id?: string;
+  tooltip?: string;
   onMouseEnter?: () => void;
   onMouseLeave?: () => void;
 } & Omit<ButtonProps, 'children'>;
@@ -40,19 +42,34 @@ export default function ActionRow({
             .flatMap((action) => (action != null ? [action] : []))
             .map(
               (
-                { icon, styling, id, onMouseEnter, onMouseLeave, ...rest },
+                {
+                  icon,
+                  styling,
+                  id,
+                  tooltip,
+                  onMouseEnter,
+                  onMouseLeave,
+                  ...rest
+                },
                 i
               ) => (
-                <Button className="action" {...rest} key={i}>
-                  <FontAwesomeIcon
-                    fixedWidth
-                    style={styling}
-                    icon={icon}
-                    id={id}
-                    onMouseEnter={onMouseEnter}
-                    onMouseLeave={onMouseLeave}
-                  />
-                </Button>
+                <>
+                  <Button className="action" {...rest} key={i}>
+                    <FontAwesomeIcon
+                      fixedWidth
+                      style={styling}
+                      icon={icon}
+                      id={id}
+                      onMouseEnter={onMouseEnter}
+                      onMouseLeave={onMouseLeave}
+                    />
+                  </Button>
+                  {tooltip && (
+                    <ReactTooltip anchorId={id} variant="dark" place="left">
+                      {tooltip}
+                    </ReactTooltip>
+                  )}
+                </>
               )
             )}
         </div>

--- a/src/components/Course/index.tsx
+++ b/src/components/Course/index.tsx
@@ -148,7 +148,7 @@ export default function Course({
     onClick: (): void => {
       prereqControl(true, !prereqOpen ? true : !expanded);
     },
-    tooltip: 'Prerequisites',
+    tooltip: 'View Prerequisites',
     id: `${course.id}-prerequisites`,
   };
 
@@ -189,21 +189,20 @@ export default function Course({
                 {
                   icon: expanded ? faAngleUp : faAngleDown,
                   onClick: (): void => prereqControl(false, !expanded),
-                  tooltip: expanded ? 'Hide Sections' : 'View Sections',
                   id: `${course.id}-expansion`,
                 },
                 hasPrereqs ? prereqAction : infoAction,
                 {
                   icon: faPalette,
                   onClick: (): void => setPaletteShown(!paletteShown),
-                  tooltip: 'Course Color',
+                  tooltip: 'Edit Color',
                   id: `${course.id}-color`,
                 },
                 {
                   icon: faTrash,
                   onClick: (): void => handleRemoveCourse(course),
-                  tooltip: 'Delete Course',
-                  id: `${course.id}-delete`,
+                  tooltip: 'Remove Course',
+                  id: `${course.id}-remove`,
                 },
               ]
         }

--- a/src/components/Course/index.tsx
+++ b/src/components/Course/index.tsx
@@ -148,6 +148,8 @@ export default function Course({
     onClick: (): void => {
       prereqControl(true, !prereqOpen ? true : !expanded);
     },
+    tooltip: 'Prerequisites',
+    id: `${course.id}-prerequisites`,
   };
 
   const infoAction = {
@@ -187,15 +189,21 @@ export default function Course({
                 {
                   icon: expanded ? faAngleUp : faAngleDown,
                   onClick: (): void => prereqControl(false, !expanded),
+                  tooltip: expanded ? 'Hide Sections' : 'View Sections',
+                  id: `${course.id}-expansion`,
                 },
                 hasPrereqs ? prereqAction : infoAction,
                 {
                   icon: faPalette,
                   onClick: (): void => setPaletteShown(!paletteShown),
+                  tooltip: 'Course Color',
+                  id: `${course.id}-color`,
                 },
                 {
                   icon: faTrash,
                   onClick: (): void => handleRemoveCourse(course),
+                  tooltip: 'Delete Course',
+                  id: `${course.id}-delete`,
                 },
               ]
         }

--- a/src/components/Course/index.tsx
+++ b/src/components/Course/index.tsx
@@ -189,7 +189,6 @@ export default function Course({
                 {
                   icon: expanded ? faAngleUp : faAngleDown,
                   onClick: (): void => prereqControl(false, !expanded),
-                  id: `${course.id}-expansion`,
                 },
                 hasPrereqs ? prereqAction : infoAction,
                 {

--- a/src/components/Event/index.tsx
+++ b/src/components/Event/index.tsx
@@ -66,10 +66,14 @@ export default function Event({
               },
               {
                 icon: faPalette,
+                tooltip: `Edit Color`,
+                id: `${event.id}-color`,
                 onClick: (): void => setPaletteShown(!paletteShown),
               },
               {
                 icon: faTrash,
+                tooltip: `Remove Event`,
+                id: `${event.id}-remove`,
                 onClick: (): void => handleRemoveEvent(event.id),
               },
             ]}

--- a/src/components/HeaderDisplay/index.tsx
+++ b/src/components/HeaderDisplay/index.tsx
@@ -202,6 +202,8 @@ function VersionSelector({ state }: VersionSelectorProps): React.ReactElement {
               state.renameVersion(version.id, newName);
               return true;
             },
+            id: `${version.id}-edit`,
+            tooltip: 'Rename Schedule',
           });
 
           // Add the duplicate button
@@ -211,6 +213,8 @@ function VersionSelector({ state }: VersionSelectorProps): React.ReactElement {
             onClick: () => {
               state.cloneVersion(version.id, `Copy of ${version.name}`);
             },
+            id: `${version.id}-copy`,
+            tooltip: 'Create a Copy',
           });
 
           // Add the delete action
@@ -222,6 +226,8 @@ function VersionSelector({ state }: VersionSelectorProps): React.ReactElement {
                 // Display a confirmation dialog before deleting the version
                 setDeleteConfirm(version);
               },
+              id: `${version.id}-delete`,
+              tooltip: 'Delete Schedule',
             });
           }
 

--- a/src/components/Instructor/index.tsx
+++ b/src/components/Instructor/index.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useContext, useId, useState } from 'react';
-import { Tooltip as ReactTooltip } from 'react-tooltip';
 import {
   faAngleDown,
   faAngleUp,
@@ -93,6 +92,7 @@ export default function Instructor({
           {
             icon: faBan,
             id: excludeTooltipId,
+            tooltip: 'Exclude from Combinations',
             onClick: (): void => excludeSections(sections),
           },
         ]}
@@ -102,9 +102,6 @@ export default function Instructor({
           <span className="gpa">Instructor GPA: {gpa || 'N/A'}</span>
         </div>
       </ActionRow>
-      <ReactTooltip anchorId={excludeTooltipId} variant="dark" place="left">
-        Exclude from Combinations
-      </ReactTooltip>
       {expanded && (
         <div className={classes('section-container', 'nested')}>
           {includedSections.map((section) => {

--- a/src/components/Instructor/index.tsx
+++ b/src/components/Instructor/index.tsx
@@ -83,9 +83,11 @@ export default function Instructor({
           !['TBA', 'Not Assigned'].includes(name)
             ? {
                 icon: faGraduationCap,
+                tooltip: 'View Instructor Ratings',
                 href: `http://www.ratemyprofessors.com/search.jsp?queryBy=teacherName&schoolName=Georgia+Institute+of+Technology&query=${encodeURIComponent(
                   simplifyName(name)
                 )}`,
+                id: `${simplifyName(name, '-').toLowerCase()}-rmp`,
               }
             : null,
           {

--- a/src/components/Section/index.tsx
+++ b/src/components/Section/index.tsx
@@ -105,19 +105,12 @@ export default function Section({
         {
           icon: faBan,
           id: excludeTooltipId,
+          tooltip: 'Exclude from Combinations',
           onClick: (): void => excludeSection(section),
         },
       ]}
       style={pinned ? { backgroundColor: color } : undefined}
     >
-      <ReactTooltip
-        anchorId={excludeTooltipId}
-        className="popover"
-        variant="dark"
-        place="left"
-      >
-        Exclude from Combinations
-      </ReactTooltip>
       <div className="section-details">
         <div className="delivery-mode">
           {section.deliveryMode != null

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { Tooltip as ReactTooltip } from 'react-tooltip';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faCaretDown,
@@ -60,6 +61,8 @@ export interface EditAction<Id extends string | number> {
   type: 'edit';
   icon: IconDefinition;
   onCommit: (newLabel: string, id: Id) => boolean;
+  id?: string;
+  tooltip?: string;
 }
 
 /**
@@ -69,6 +72,8 @@ export interface ButtonAction<Id extends string | number> {
   type: 'button';
   icon: IconDefinition;
   onClick: (id: Id) => void;
+  id?: string;
+  tooltip?: string;
 }
 
 /**
@@ -203,19 +208,34 @@ export default function Select<Id extends string | number>({
               {actions.map((action, i) => (
                 <React.Fragment key={i}>
                   {action.type === 'button' ? (
-                    <Button
-                      className="option__action-button"
-                      onClick={(e): void => {
-                        e.stopPropagation();
+                    <>
+                      <Button
+                        className="option__action-button"
+                        onClick={(e): void => {
+                          e.stopPropagation();
 
-                        // Abandon any in-progress edit
-                        if (inputId !== null) abandonEdit();
+                          // Abandon any in-progress edit
+                          if (inputId !== null) abandonEdit();
 
-                        action.onClick(optionId);
-                      }}
-                    >
-                      <FontAwesomeIcon fixedWidth icon={action.icon} />
-                    </Button>
+                          action.onClick(optionId);
+                        }}
+                      >
+                        <FontAwesomeIcon
+                          fixedWidth
+                          id={action.id}
+                          icon={action.icon}
+                        />
+                      </Button>
+                      {action.tooltip && (
+                        <ReactTooltip
+                          anchorId={action.id}
+                          variant="dark"
+                          place="left"
+                        >
+                          {action.tooltip}
+                        </ReactTooltip>
+                      )}
+                    </>
                   ) : (
                     <>
                       {optionId === inputId ? (
@@ -240,18 +260,33 @@ export default function Select<Id extends string | number>({
                           </Button>
                         </>
                       ) : (
-                        <Button
-                          className="option__action-button"
-                          onClick={(e): void => {
-                            e.stopPropagation();
-                            // Start a new edit (ignore any in-progress edits)
-                            setInputId(optionId);
-                            setInputValue(optionLabel);
-                            setInputEditAction(action);
-                          }}
-                        >
-                          <FontAwesomeIcon fixedWidth icon={action.icon} />
-                        </Button>
+                        <>
+                          <Button
+                            className="option__action-button"
+                            onClick={(e): void => {
+                              e.stopPropagation();
+                              // Start a new edit (ignore any in-progress edits)
+                              setInputId(optionId);
+                              setInputValue(optionLabel);
+                              setInputEditAction(action);
+                            }}
+                          >
+                            <FontAwesomeIcon
+                              fixedWidth
+                              icon={action.icon}
+                              id={action.id}
+                            />
+                          </Button>
+                          {action.tooltip && (
+                            <ReactTooltip
+                              anchorId={action.id}
+                              variant="dark"
+                              place="left"
+                            >
+                              {action.tooltip}
+                            </ReactTooltip>
+                          )}
+                        </>
                       )}
                     </>
                   )}

--- a/src/utils/misc.tsx
+++ b/src/utils/misc.tsx
@@ -112,11 +112,11 @@ export const classes = (
 
 export const isMobile = (): boolean => window.innerWidth < 1024;
 
-export const simplifyName = (name: string): string => {
+export const simplifyName = (name: string, delimiter?: string): string => {
   const tokens = name.split(' ');
   const firstName = tokens.shift();
   const lastName = tokens.pop();
-  return [firstName, lastName].join(' ');
+  return [firstName, lastName].join(delimiter ?? ' ');
 };
 
 export function unique<T>(array: T[]): T[] {


### PR DESCRIPTION
### Summary

Resolves #178 

Adds preview labels to some buttons.

### Checklist

- [x] Make sure buttons for each schedule display preview text box with text upon hover
  - [x] Make sure hovering over `Rename Schedule` button displays preview text box with text "Rename Schedule"
  - [x] Make sure hovering over `Create a Copy of Schedule` button displays preview text box with text "Create a Copy"
  - [x] Make sure hovering over `Delete Schedule` button displays preview text box with text "Delete Schedule"
- [x] Make sure buttons for each course display preview text box with text upon hover
  - [ ] Make sure hovering over `Down Arrow to Expand` button displays preview text box with text "View Sections and Waitlists" (did not implement as this would interfere with the seating info popup)
  - [x] Make sure hovering over `Prerequisites` button displays preview text box with text "View Prerequisites"
  - [x] Make sure hovering over `Course Color` button displays preview text box with text "Edit Color"
  - [x] Make sure hovering over `Delete Course` button displays preview text box with text "Remove Course"
    

### How to Test
Hover over buttons
