### PR TITLE
Sophia/182 fix modal

### DIFF
--- a/src/components/InvitationModal/index.tsx
+++ b/src/components/InvitationModal/index.tsx
@@ -8,6 +8,8 @@ import React, {
 import { Tooltip as ReactTooltip } from 'react-tooltip';
 import { faCircle, faClose } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { DESKTOP_BREAKPOINT } from '../../constants';
+import useScreenWidth from '../../hooks/useScreenWidth';
 
 import { classes } from '../../utils/misc';
 import Modal from '../Modal';
@@ -19,12 +21,16 @@ import './stylesheet.scss';
  * Inner content of the invitation modal.
  */
 export function InvitationModalContent(): React.ReactElement {
+  const mobile = !useScreenWidth(DESKTOP_BREAKPOINT);
   // Array for testing style of shared emails
   // eslint-disable-next-line
   const [emails, setEmails] = useState([
     ['user1@example.com', 'Pending'],
     ['user2@example.com', 'Accepted'],
-    ['ReallyLongNameThatWillNotFitInRowAbove@example.com', 'Accepted'],
+    [
+      'SuperDuperExtraReallyLongNameThatWillNotFitInRowAbove@example.com',
+      'Accepted',
+    ],
     ['goodEmail@gmail.com', 'Accepted'],
     ['user12@example.com', 'Pending'],
     ['user22@example.com', 'Accepted'],
@@ -134,7 +140,7 @@ export function InvitationModalContent(): React.ReactElement {
   }
 
   return (
-    <div className="invitation-modal-content">
+    <div className={classes('invitation-modal-content', mobile && 'mobile')}>
       <div className="top-block">
         <h2>Share Schedule</h2>
         <p>
@@ -188,7 +194,7 @@ export function InvitationModalContent(): React.ReactElement {
           {emails.map((element) => (
             <div className="email-and-status" id={element[0]}>
               <div className="individual-shared-email" id={element[1]}>
-                {element[0]}
+                <p className="email-text">{element[0]}</p>
                 <Button className="button-remove">
                   <FontAwesomeIcon className="circle" icon={faCircle} />
                   <FontAwesomeIcon className="remove" icon={faClose} />

--- a/src/components/InvitationModal/stylesheet.scss
+++ b/src/components/InvitationModal/stylesheet.scss
@@ -271,6 +271,7 @@
     align-items: center;
     .email-input {
       max-width: 100%;
+      margin-bottom: 6px;
       .email {
         max-width: 100%;
       }

--- a/src/components/InvitationModal/stylesheet.scss
+++ b/src/components/InvitationModal/stylesheet.scss
@@ -172,8 +172,7 @@
             justify-content: center;
             border-radius: 16px;
             width: max-content;
-            max-width: 100%;
-            min-width: min-content;
+            max-width: calc(100% - 8px);
             font-size: .9em;
             cursor: pointer;
 
@@ -181,12 +180,20 @@
                 background-color: rgba($color-neutral, 0.5);
                 opacity: 0.75;
             }
+
+            .email-text {
+              margin: 0px;
+              flex: 1;
+              overflow: hidden;
+              text-overflow: ellipsis;
+            }
         }
     }
 
     .email-and-status {
         display: flex;
         flex-direction: column;
+        max-width: 100%;
     }
 
     .status-tooltip {
@@ -255,4 +262,17 @@
         border-style: solid;
         border-width: 1.5px;
     }
+}
+
+.mobile.invitation-modal-content {
+  .email-input-block {
+    flex-direction: column;
+    align-items: center;
+    .email-input {
+      max-width: 100%;
+      .email {
+        max-width: 100%;
+      }
+    }
+  }
 }

--- a/src/components/InvitationModal/stylesheet.scss
+++ b/src/components/InvitationModal/stylesheet.scss
@@ -100,6 +100,7 @@
 
     #recent-invites {
         width: 282px;
+        max-width: 100%;
         max-height: 96px;
         overflow-y: scroll;
         border-radius: 4px;


### PR DESCRIPTION
### Summary

Resolves #182 

Fixes mobile view for invitation modal.

### Checklist
- [ ] Input field and text-overflow (including email and schedule's name) are adjusted automatically to fit the screen ratio.
- [ ] Modal should be fixed (i.e., nothing aside from the list of emails is able to move).

### How to Test
Open share schedule and switch to mobile view.
