### PR TITLE
Implement Drag and Drop for Custom Events

### DIFF
--- a/src/components/Calendar/index.tsx
+++ b/src/components/Calendar/index.tsx
@@ -52,6 +52,9 @@ export default function Calendar({
     Record<string, Record<string, EventBlockPosition>>
   > = {};
 
+  const daysRef = React.useRef<HTMLDivElement>(null);
+  const timesRef = React.useRef<HTMLDivElement>(null);
+
   // Recursively sets the rowSize of all time blocks within the current
   // connected grouping of blocks to the current block's rowSize
   const updateJoinedRowSizes = (
@@ -258,7 +261,7 @@ export default function Calendar({
       )}
     >
       {!preview && (
-        <div className="times">
+        <div className="times" ref={timesRef}>
           {new Array((CLOSE - OPEN) / 60).fill(0).map((_, i) => {
             const time = OPEN + i * 60;
             return (
@@ -270,7 +273,7 @@ export default function Calendar({
         </div>
       )}
       {!preview && (
-        <div className="days">
+        <div className="days" ref={daysRef}>
           {DAYS.map((day) => (
             <div className="day" key={day}>
               <span className="label">{day}</span>
@@ -339,6 +342,8 @@ export default function Calendar({
                   setSelectedMeeting([event.id, meeting[0], meeting[1]]);
                 }
               }}
+              daysRef={daysRef}
+              timesRef={timesRef}
             />
           ))}
       </div>

--- a/src/components/Calendar/index.tsx
+++ b/src/components/Calendar/index.tsx
@@ -330,18 +330,6 @@ export default function Calendar({
               includeContent={!preview}
               canBeTabFocused={!isAutosized && !capture}
               deviceHasHover={deviceHasHover}
-              selectedMeeting={
-                selectedMeeting !== null && selectedMeeting[0] === event.id
-                  ? [selectedMeeting[1], selectedMeeting[2]]
-                  : null
-              }
-              onSelectMeeting={(meeting: [number, string] | null): void => {
-                if (meeting === null) {
-                  setSelectedMeeting(null);
-                } else {
-                  setSelectedMeeting([event.id, meeting[0], meeting[1]]);
-                }
-              }}
               daysRef={daysRef}
               timesRef={timesRef}
             />

--- a/src/components/Calendar/index.tsx
+++ b/src/components/Calendar/index.tsx
@@ -332,6 +332,7 @@ export default function Calendar({
               deviceHasHover={deviceHasHover}
               daysRef={daysRef}
               timesRef={timesRef}
+              key={`${event.id}-${event.period.start}-${event.days.join()}`}
               selectedMeeting={
                 selectedMeeting !== null && selectedMeeting[0] === event.id
                   ? [selectedMeeting[1], selectedMeeting[2]]

--- a/src/components/Calendar/index.tsx
+++ b/src/components/Calendar/index.tsx
@@ -332,6 +332,18 @@ export default function Calendar({
               deviceHasHover={deviceHasHover}
               daysRef={daysRef}
               timesRef={timesRef}
+              selectedMeeting={
+                selectedMeeting !== null && selectedMeeting[0] === event.id
+                  ? [selectedMeeting[1], selectedMeeting[2]]
+                  : null
+              }
+              onSelectMeeting={(meeting: [number, string] | null): void => {
+                if (meeting === null) {
+                  setSelectedMeeting(null);
+                } else {
+                  setSelectedMeeting([event.id, meeting[0], meeting[1]]);
+                }
+              }}
             />
           ))}
       </div>

--- a/src/components/Event/index.tsx
+++ b/src/components/Event/index.tsx
@@ -102,6 +102,7 @@ export default function Event({
         <EventAdd
           className="event-add"
           event={event}
+          key={`${event.id}-${event.period.start}-${event.days.join()}`}
           setFormShown={setFormShown}
         />
       )}

--- a/src/components/EventBlocks/index.tsx
+++ b/src/components/EventBlocks/index.tsx
@@ -67,9 +67,7 @@ export default function EventBlocks({
   // Start dragging a block. This event handler is passed down to each block
   const handleMouseDown = (
     e: React.MouseEvent,
-    ref: React.RefObject<HTMLDivElement>,
-    meetingIndex: number,
-    meetingDay: string
+    ref: React.RefObject<HTMLDivElement>
   ): void => {
     if (!ref.current) return;
     if (!deviceHasHover) return;

--- a/src/components/EventBlocks/index.tsx
+++ b/src/components/EventBlocks/index.tsx
@@ -202,7 +202,7 @@ export default function EventBlocks({
                 content: periodToString({
                   start: tempStart ?? event.period.start,
                   end:
-                    (tempStart ?? event.period.start) +
+                    (tempStartRef.current ?? event.period.start) +
                     (event.period.end - event.period.start),
                 }),
               },

--- a/src/components/EventBlocks/index.tsx
+++ b/src/components/EventBlocks/index.tsx
@@ -128,11 +128,6 @@ export default function EventBlocks({
 
       patchSchedule({ events: newEvents });
 
-      const day: string =
-        event.days.length === 1 && tempDaysRef.current[0]
-          ? tempDaysRef.current[0]
-          : meetingDay;
-
       // Clean up the event listeners once done dragging
       document.removeEventListener('mousemove', mouseMoveHandler);
       document.removeEventListener('mouseup', documentMouseUp);

--- a/src/components/EventBlocks/index.tsx
+++ b/src/components/EventBlocks/index.tsx
@@ -1,11 +1,12 @@
-import React, { ReactElement, useState } from 'react';
-import { Immutable } from 'immer';
+import React, { ReactElement, useState, useContext, useRef } from 'react';
+import { Immutable, castDraft } from 'immer';
 
 import { daysToString, periodToString } from '../../utils/misc';
 import { TimeBlocks } from '..';
 import { Period, Event } from '../../types';
 import { TimeBlockPosition, SizeInfo } from '../TimeBlocks';
 import { CLOSE, OPEN } from '../../constants';
+import { ThemeContext, ScheduleContext } from '../../contexts';
 
 import './stylesheet.scss';
 
@@ -48,6 +49,15 @@ export default function EventBlocks({
   timesRef,
 }: EventBlocksProps): React.ReactElement | null {
   const [tempStart, setTempStart] = useState<number>(event.period.start);
+  const [tempDays, setTempDays] = useState<string[]>([...event.days]);
+
+  const tempStartRef = useRef<number>(event.period.start);
+  const tempDaysRef = useRef<string[]>([...event.days]);
+
+  const [dragging, setDragging] = useState<boolean>(false);
+  const [theme] = useContext(ThemeContext);
+
+  const [{ events }, { patchSchedule }] = useContext(ScheduleContext);
 
   const handleMouseDown = (
     e: React.MouseEvent,
@@ -56,19 +66,45 @@ export default function EventBlocks({
     const cloneMeeting = ref.current!.cloneNode(true) as HTMLDivElement;
     cloneMeeting.classList.add('meeting--clone');
     cloneMeeting.id = 'meeting--clone';
+
+    setDragging(true);
+
+    ref.current?.classList.remove('light-content', 'dark-content');
+    ref.current?.classList.add(`${theme}-content`);
     ref.current?.parentNode?.appendChild(cloneMeeting);
     ref.current?.classList.add('meeting--dragging');
+
     // eslint-disable-next-line
     const mouseMoveHandler = (e_: any): void => handleMouseMove(e_, ref);
+
     const handleMouseUp = (
       e_: React.MouseEvent,
       ref_: React.RefObject<HTMLDivElement>
     ): void => {
       ref_.current?.classList.remove('meeting--dragging');
       cloneMeeting.remove();
+      setDragging(false);
+
+      const newEvents = castDraft(events).map((existingEvent: Event) => {
+        if (existingEvent.id === event.id) {
+          return {
+            ...existingEvent,
+            period: {
+              start: tempStartRef.current,
+              end: tempStartRef.current + event.period.end - event.period.start,
+            },
+            days: tempDaysRef.current,
+          };
+        }
+        return existingEvent;
+      });
+
+      patchSchedule({ events: newEvents });
+
       document.removeEventListener('mousemove', mouseMoveHandler);
       document.removeEventListener('mouseup', documentMouseUp);
     };
+
     // eslint-disable-next-line
     const documentMouseUp = (e_: any): void => handleMouseUp(e_, ref);
 
@@ -100,10 +136,13 @@ export default function EventBlocks({
     if (day && event.days.length === 1) {
       ref.current!.classList.remove('M', 'T', 'W', 'R', 'F');
       ref.current!.classList.add(day);
+      setTempDays([day]);
+      tempDaysRef.current = [day];
     }
-    console.log(ref.current!.classList);
+
     if (start >= OPEN && end <= CLOSE) {
       setTempStart(start);
+      tempStartRef.current = start;
     }
   };
 
@@ -151,12 +190,10 @@ export default function EventBlocks({
       ]}
       capture={capture}
       sizeInfo={sizeInfo}
-      includeDetailsPopover={includeDetailsPopover}
+      includeDetailsPopover={!dragging && includeDetailsPopover}
       includeContent={includeContent}
       canBeTabFocused={canBeTabFocused}
       deviceHasHover={deviceHasHover}
-      selectedMeeting={selectedMeeting}
-      onSelectMeeting={onSelectMeeting}
       handleMouseDown={handleMouseDown}
     />
   );

--- a/src/components/EventBlocks/index.tsx
+++ b/src/components/EventBlocks/index.tsx
@@ -149,7 +149,7 @@ export default function EventBlocks({
     // math which calculates the new start time by calculating mouse
     // position proportional to calendar size, then we find new time
     // by rounding to nearest 5
-    const start =
+    let start =
       Math.round(
         ((Math.round(
           e.pageY -
@@ -174,10 +174,14 @@ export default function EventBlocks({
       tempDaysRef.current = [day];
     }
 
-    if (start >= OPEN && end <= CLOSE) {
-      setTempStart(start);
-      tempStartRef.current = start;
+    if (start < OPEN) {
+      start = OPEN;
+    } else if (end > CLOSE) {
+      start = CLOSE - (event.period.end - event.period.start);
     }
+
+    setTempStart(start);
+    tempStartRef.current = start;
   };
 
   return (

--- a/src/components/EventBlocks/index.tsx
+++ b/src/components/EventBlocks/index.tsx
@@ -67,7 +67,9 @@ export default function EventBlocks({
   // Start dragging a block. This event handler is passed down to each block
   const handleMouseDown = (
     e: React.MouseEvent,
-    ref: React.RefObject<HTMLDivElement>
+    ref: React.RefObject<HTMLDivElement>,
+    meetingIndex: number,
+    meetingDay: string
   ): void => {
     if (!ref.current) return;
     if (!deviceHasHover) return;
@@ -125,6 +127,11 @@ export default function EventBlocks({
       });
 
       patchSchedule({ events: newEvents });
+
+      const day: string =
+        event.days.length === 1 && tempDaysRef.current[0]
+          ? tempDaysRef.current[0]
+          : meetingDay;
 
       // Clean up the event listeners once done dragging
       document.removeEventListener('mousemove', mouseMoveHandler);

--- a/src/components/EventBlocks/index.tsx
+++ b/src/components/EventBlocks/index.tsx
@@ -28,6 +28,10 @@ export type EventBlocksProps = {
   deviceHasHover?: boolean;
   daysRef: React.RefObject<HTMLDivElement>;
   timesRef: React.RefObject<HTMLDivElement>;
+  selectedMeeting?: [meetingIndex: number, day: string] | null;
+  onSelectMeeting?: (
+    meeting: [meetingIndex: number, day: string] | null
+  ) => void;
 };
 
 export default function EventBlocks({
@@ -41,6 +45,8 @@ export default function EventBlocks({
   deviceHasHover = true,
   daysRef,
   timesRef,
+  selectedMeeting,
+  onSelectMeeting,
 }: EventBlocksProps): React.ReactElement | null {
   const [tempStart, setTempStart] = useState<number>(event.period.start);
 
@@ -64,7 +70,7 @@ export default function EventBlocks({
     ref: React.RefObject<HTMLDivElement>
   ): void => {
     if (!ref.current) return;
-
+    if (!deviceHasHover) return;
     // Save style of the block
     savedStyleRef.current = ref.current.style.cssText;
     savedClassListRef.current = ref.current.className;
@@ -221,6 +227,8 @@ export default function EventBlocks({
       includeDetailsPopover={!dragging && includeDetailsPopover}
       includeContent={includeContent}
       canBeTabFocused={canBeTabFocused}
+      onSelectMeeting={onSelectMeeting}
+      selectedMeeting={selectedMeeting}
       deviceHasHover={deviceHasHover}
       handleMouseDown={handleMouseDown}
     />

--- a/src/components/SectionBlocks/index.tsx
+++ b/src/components/SectionBlocks/index.tsx
@@ -59,6 +59,7 @@ export default function SectionBlocks({
           <TimeBlocks
             className={className}
             id={section.course.id}
+            key={`${section.course.id}-${period.start}`}
             meetingIndex={i}
             period={period}
             days={meeting.days.filter((day) => day !== 'S' && day !== 'U')}

--- a/src/components/TimeBlocks/index.tsx
+++ b/src/components/TimeBlocks/index.tsx
@@ -59,15 +59,9 @@ export type TimeBlocksProps = {
   ) => void;
   handleMouseDown?: (
     e: React.MouseEvent,
-    ref: React.RefObject<HTMLDivElement>
-  ) => void;
-  handleMouseUp?: (
-    e: React.MouseEvent,
-    ref: React.RefObject<HTMLDivElement>
-  ) => void;
-  handleMouseMove?: (
-    e: React.MouseEvent,
-    ref: React.RefObject<HTMLDivElement>
+    ref: React.RefObject<HTMLDivElement>,
+    meetingIndex: number,
+    meetingDay: string
   ) => void;
 };
 
@@ -95,8 +89,6 @@ export default function TimeBlocks({
   selectedMeeting,
   onSelectMeeting,
   handleMouseDown,
-  handleMouseUp,
-  handleMouseMove,
 }: TimeBlocksProps): React.ReactElement | null {
   const [{ colorMap }] = useContext(ScheduleContext);
   const color = colorMap[id];
@@ -147,8 +139,8 @@ export default function TimeBlocks({
             // Only the first day for a meeting can be tab focused
             canBeTabFocused={canBeTabFocused && i === 0}
             handleMouseDown={handleMouseDown}
-            handleMouseUp={handleMouseUp}
-            handleMouseMove={handleMouseMove}
+            meetingIndex={meetingIndex}
+            meetingDay={day}
           />
         );
       })}
@@ -173,16 +165,12 @@ type MeetingDayBlockProps = {
   deviceHasHover: boolean;
   handleMouseDown?: (
     e: React.MouseEvent,
-    ref: React.RefObject<HTMLDivElement>
+    ref: React.RefObject<HTMLDivElement>,
+    meetingIndex: number,
+    meetingDay: string
   ) => void;
-  handleMouseUp?: (
-    e: React.MouseEvent,
-    ref: React.RefObject<HTMLDivElement>
-  ) => void;
-  handleMouseMove?: (
-    e: React.MouseEvent,
-    ref: React.RefObject<HTMLDivElement>
-  ) => void;
+  meetingIndex: number;
+  meetingDay: string;
 };
 
 function MeetingDayBlock({
@@ -201,8 +189,8 @@ function MeetingDayBlock({
   onSelect,
   deviceHasHover,
   handleMouseDown,
-  handleMouseUp,
-  handleMouseMove,
+  meetingIndex,
+  meetingDay,
 }: MeetingDayBlockProps): React.ReactElement {
   const tooltipId = useId();
   const contentClassName = getContentClassName(color);
@@ -216,6 +204,7 @@ function MeetingDayBlock({
   });
   const [isHovered, setIsHovered] = React.useState(false);
   const BlockElement = canBeTabFocused ? 'button' : 'div';
+
   return (
     <div ref={outerRef}>
       <BlockElement
@@ -266,17 +255,7 @@ function MeetingDayBlock({
         ref={blockElementRef}
         onMouseDown={(e): void => {
           if (handleMouseDown) {
-            handleMouseDown(e, blockElementRef);
-          }
-        }}
-        onMouseUp={(e): void => {
-          if (handleMouseUp) {
-            handleMouseUp(e, blockElementRef);
-          }
-        }}
-        onMouseMove={(e): void => {
-          if (handleMouseMove) {
-            handleMouseMove(e, blockElementRef);
+            handleMouseDown(e, blockElementRef, meetingIndex, meetingDay);
           }
         }}
       >

--- a/src/components/TimeBlocks/index.tsx
+++ b/src/components/TimeBlocks/index.tsx
@@ -214,7 +214,6 @@ function MeetingDayBlock({
   useRootClose(outerRef, handleRootClose, {
     disabled: !isSelected,
   });
-
   const [isHovered, setIsHovered] = React.useState(false);
   const BlockElement = canBeTabFocused ? 'button' : 'div';
   return (
@@ -224,12 +223,15 @@ function MeetingDayBlock({
           'meeting',
           contentClassName,
           'default',
-          day,
+          // day,
           isSelected && 'meeting--selected'
         )}
         style={{
           top: `${
             (((tempStart ?? period.start) - OPEN) / (CLOSE - OPEN)) * 100
+          }%`,
+          left: `${
+            DAYS.indexOf(day) * 20 + sizeInfo.rowIndex * (20 / sizeInfo.rowSize)
           }%`,
           height: `${
             (Math.max(15, period.end - period.start) / (CLOSE - OPEN)) * 100

--- a/src/components/TimeBlocks/index.tsx
+++ b/src/components/TimeBlocks/index.tsx
@@ -59,9 +59,7 @@ export type TimeBlocksProps = {
   ) => void;
   handleMouseDown?: (
     e: React.MouseEvent,
-    ref: React.RefObject<HTMLDivElement>,
-    meetingIndex: number,
-    meetingDay: string
+    ref: React.RefObject<HTMLDivElement>
   ) => void;
 };
 
@@ -139,8 +137,6 @@ export default function TimeBlocks({
             // Only the first day for a meeting can be tab focused
             canBeTabFocused={canBeTabFocused && i === 0}
             handleMouseDown={handleMouseDown}
-            meetingIndex={meetingIndex}
-            meetingDay={day}
           />
         );
       })}
@@ -165,12 +161,8 @@ type MeetingDayBlockProps = {
   deviceHasHover: boolean;
   handleMouseDown?: (
     e: React.MouseEvent,
-    ref: React.RefObject<HTMLDivElement>,
-    meetingIndex: number,
-    meetingDay: string
+    ref: React.RefObject<HTMLDivElement>
   ) => void;
-  meetingIndex: number;
-  meetingDay: string;
 };
 
 function MeetingDayBlock({
@@ -189,8 +181,6 @@ function MeetingDayBlock({
   onSelect,
   deviceHasHover,
   handleMouseDown,
-  meetingIndex,
-  meetingDay,
 }: MeetingDayBlockProps): React.ReactElement {
   const tooltipId = useId();
   const contentClassName = getContentClassName(color);
@@ -255,7 +245,7 @@ function MeetingDayBlock({
         ref={blockElementRef}
         onMouseDown={(e): void => {
           if (handleMouseDown) {
-            handleMouseDown(e, blockElementRef, meetingIndex, meetingDay);
+            handleMouseDown(e, blockElementRef);
           }
         }}
       >

--- a/src/components/TimeBlocks/stylesheet.scss
+++ b/src/components/TimeBlocks/stylesheet.scss
@@ -71,6 +71,19 @@
       }
     }
 
+    &--clone {
+      & {
+        opacity: 0.5;
+      }
+    }
+
+    &--dragging {
+      & {
+        background-color: transparent;
+        border: 2px solid var(--meeting-color, $color-neutral);
+      }
+    }
+
     :hover {
       cursor: pointer;
     }


### PR DESCRIPTION
### Summary

Resolves #176 

Enabled drag and drop functionality for events. Users can change day and time of events with a single day and only the time of events with multiple days by dragging them. 

NOTE: Events can't be selected on desktop screens anymore, but can do further work to make drag and drop work with select functionality as well if required.

### Checklist
- [x] User can click on the an `EventBlock` and drag it around.
- [x] While the `EventBlock` is being dragged, the block at the original time should be "blurred"
- [x] Wherever the user drop the `EventBlock`, the event's time info should be updated in `ScheduleContext`.
- [x] UI works for both light and dark modes.

### How to Test
Add an event and try dragging it.
