### PR TITLE
Recurring Events Export

### DIFF
--- a/src/components/EventAdd/index.tsx
+++ b/src/components/EventAdd/index.tsx
@@ -101,8 +101,6 @@ export default function EventAdd({
   );
 
   const onSubmit = useCallback((): void => {
-    const roundedStart = Math.floor(parseTime(start) / 5) * 5;
-    const roundedEnd = Math.floor(parseTime(end) / 5) * 5;
     if (event) {
       const newEvents = castDraft(events).map((existingEvent) =>
         existingEvent.id === event.id
@@ -110,8 +108,8 @@ export default function EventAdd({
               ...existingEvent,
               name: eventName,
               period: {
-                start: roundedStart,
-                end: roundedEnd,
+                start: parseTime(start),
+                end: parseTime(end),
               },
               days: selectedTags,
             }
@@ -131,8 +129,8 @@ export default function EventAdd({
         id: eventId,
         name: eventName,
         period: {
-          start: roundedStart,
-          end: roundedEnd,
+          start: parseTime(start),
+          end: parseTime(end),
         },
         days: selectedTags,
       };

--- a/src/components/EventAdd/index.tsx
+++ b/src/components/EventAdd/index.tsx
@@ -101,6 +101,9 @@ export default function EventAdd({
   );
 
   const onSubmit = useCallback((): void => {
+    const parsedStart = parseTime(start);
+    const parsedEnd = parseTime(end);
+
     if (event) {
       const newEvents = castDraft(events).map((existingEvent) =>
         existingEvent.id === event.id
@@ -108,8 +111,8 @@ export default function EventAdd({
               ...existingEvent,
               name: eventName,
               period: {
-                start: parseTime(start),
-                end: parseTime(end),
+                start: parsedStart,
+                end: parsedEnd,
               },
               days: selectedTags,
             }
@@ -129,8 +132,8 @@ export default function EventAdd({
         id: eventId,
         name: eventName,
         period: {
-          start: parseTime(start),
-          end: parseTime(end),
+          start: parsedStart,
+          end: parsedEnd,
         },
         days: selectedTags,
       };

--- a/src/components/EventAdd/index.tsx
+++ b/src/components/EventAdd/index.tsx
@@ -75,7 +75,7 @@ export default function EventAdd({
       const parsedEnd = parseTime(end);
       if (parsedEnd !== -1 && parsedEnd <= parsedStart) {
         setError('Start time must be before end time.');
-      } else if (parsedStart < 480 || parsedEnd > 1260) {
+      } else if (parsedStart < 480 || parsedEnd > 1320) {
         setError('Event must be between 08:00 AM and 10:00 PM.');
       }
     },
@@ -93,7 +93,7 @@ export default function EventAdd({
       const parsedEnd = parseTime(newEnd);
       if (parsedStart !== -1 && parsedEnd <= parsedStart) {
         setError('Start time must be before end time.');
-      } else if (parsedStart < 480 || parsedEnd > 1260) {
+      } else if (parsedStart < 480 || parsedEnd > 1320) {
         setError('Event must be between 08:00 AM and 10:00 PM.');
       }
     },
@@ -101,6 +101,8 @@ export default function EventAdd({
   );
 
   const onSubmit = useCallback((): void => {
+    const roundedStart = Math.floor(parseTime(start) / 5) * 5;
+    const roundedEnd = Math.floor(parseTime(end) / 5) * 5;
     if (event) {
       const newEvents = castDraft(events).map((existingEvent) =>
         existingEvent.id === event.id
@@ -108,8 +110,8 @@ export default function EventAdd({
               ...existingEvent,
               name: eventName,
               period: {
-                start: parseTime(start),
-                end: parseTime(end),
+                start: roundedStart,
+                end: roundedEnd,
               },
               days: selectedTags,
             }
@@ -129,8 +131,8 @@ export default function EventAdd({
         id: eventId,
         name: eventName,
         period: {
-          start: parseTime(start),
-          end: parseTime(end),
+          start: roundedStart,
+          end: roundedEnd,
         },
         days: selectedTags,
       };

--- a/src/hooks/useHeaderActionBarProps.ts
+++ b/src/hooks/useHeaderActionBarProps.ts
@@ -26,13 +26,13 @@ export type HookResult = Pick<
 export default function useHeaderActionBarProps(
   captureRef: React.RefObject<HTMLDivElement>
 ): HookResult {
-  const [{ oscar, pinnedCrns }] = useContext(ScheduleContext);
+  const [{ oscar, pinnedCrns, events, term }] = useContext(ScheduleContext);
   const [theme] = useContext(ThemeContext);
   const accountState = useContext(AccountContext);
 
   const handleExport = useCallback(() => {
     try {
-      exportCoursesToCalendar(oscar, pinnedCrns);
+      exportCoursesToCalendar(oscar, pinnedCrns, events, term);
     } catch (err) {
       softError(
         new ErrorWithFields({
@@ -44,7 +44,7 @@ export default function useHeaderActionBarProps(
         })
       );
     }
-  }, [oscar, pinnedCrns]);
+  }, [oscar, pinnedCrns, events, term]);
 
   const handleDownload = useCallback(() => {
     const captureElement = captureRef.current;
@@ -85,9 +85,9 @@ export default function useHeaderActionBarProps(
     onCopyCrns: handleCopyCrns,
     enableCopyCrns: pinnedCrns.length > 0,
     onExportCalendar: handleExport,
-    enableDownloadCalendar: pinnedCrns.length > 0,
+    enableDownloadCalendar: pinnedCrns.length > 0 || events.length > 0,
     onDownloadCalendar: handleDownload,
-    enableExportCalendar: pinnedCrns.length > 0,
+    enableExportCalendar: pinnedCrns.length > 0 || events.length > 0,
     accountState,
   };
 }

--- a/src/utils/misc.tsx
+++ b/src/utils/misc.tsx
@@ -10,6 +10,7 @@ import { Oscar, Section } from '../data/beans';
 import { DAYS, PALETTE, PNG_SCALE_FACTOR } from '../constants';
 import { ErrorWithFields, softError } from '../log';
 import {
+  DateRange,
   Event,
   ICS,
   Meeting,
@@ -243,6 +244,8 @@ export async function sleep({
   });
 }
 
+// Object that stores the estimated date range for a semester.
+// Used to estimate the date range of recurring events.
 const termDates: Record<string, { from: string; to: string }> = {
   Spring: {
     from: '05 Jan',
@@ -258,7 +261,7 @@ const termDates: Record<string, { from: string; to: string }> = {
   },
 };
 
-const getDateRange = (term: string): { from: Date; to: Date } => {
+const getDateRange = (term: string): DateRange => {
   const [sem, year] = getSemesterName(term).split(' ');
   const defaultRange = { from: new Date(), to: new Date() };
   if (!sem || !year) return defaultRange;

--- a/src/utils/misc.tsx
+++ b/src/utils/misc.tsx
@@ -4,7 +4,7 @@ import { DelayFactory } from 'exponential-backoff/dist/delay/delay.factory';
 import { getSanitizedOptions } from 'exponential-backoff/dist/options';
 import domtoimage from 'dom-to-image';
 import { saveAs } from 'file-saver';
-import { Immutable, castImmutable } from 'immer';
+import { Immutable } from 'immer';
 
 import { Oscar, Section } from '../data/beans';
 import { DAYS, PALETTE, PNG_SCALE_FACTOR } from '../constants';


### PR DESCRIPTION
### Summary

Resolves: N/A

With the addition of recurring events, we want users to be able to export their events as well into a `.ics` calendar or image. However, having only recurring events in the schedule does not enable this feature. Moreso, the exported `.ics` calendar does not contain recurring events. This PR fixes these issues and other minor bugs.

### Checklist

- [x] Fixed export not enabling with only recurring events
- [x] Fixed export to calendar not exporting recurring events
- [x] Fixed not being able to set start/end time between 9 PM and 10 PM
- [ ] Rounded event start and end times to multiples of 5 on submit in the EventAdd tab


### How to Test
- Add events and try exporting to calendar or image
