### PR TITLE
Add hyperlink to oscar when seats button clicked

### DIFF
--- a/src/components/Course/index.tsx
+++ b/src/components/Course/index.tsx
@@ -6,6 +6,7 @@ import {
   faPalette,
   faPlus,
   faTrash,
+  faInfoCircle,
 } from '@fortawesome/free-solid-svg-icons';
 
 import { classes, getContentClassName } from '../../utils/misc';
@@ -143,6 +144,14 @@ export default function Course({
     onClick: (): void => {
       prereqControl(true, !prereqOpen ? true : !expanded);
     },
+  };
+
+  const infoAction = {
+    icon: faInfoCircle,
+    href:
+      `https://oscar.gatech.edu/pls/bprod/bwckctlg.p_disp_` +
+      `course_detail?cat_term_in=${course.term}&subj_code_in=` +
+      `${course.subject}&crse_numb_in=${course.number}`,
   };
 
   const pinnedSections = course.sections.filter((section) =>

--- a/src/components/Prerequisite/index.tsx
+++ b/src/components/Prerequisite/index.tsx
@@ -1,5 +1,9 @@
 import React, { useState } from 'react';
-import { faAngleUp, faAngleDown } from '@fortawesome/free-solid-svg-icons';
+import {
+  faAngleUp,
+  faAngleDown,
+  faInfoCircle,
+} from '@fortawesome/free-solid-svg-icons';
 
 import { classes, serializePrereqs } from '../../utils/misc';
 import { ActionRow } from '..';
@@ -146,6 +150,7 @@ type PrerequisiteClauseDisplayProps = {
  * an operator at the end of each item's text to indicate that each item
  * is part of a larger prereq set.
  */
+
 function PrerequisiteClauseDisplay({
   clause,
 }: PrerequisiteClauseDisplayProps): React.ReactElement {

--- a/src/components/Section/index.tsx
+++ b/src/components/Section/index.tsx
@@ -100,6 +100,7 @@ export default function Section({
         {
           icon: faChair,
           id: sectionTooltipId,
+          href: `https://oscar.gatech.edu/pls/bprod/bwckschd.p_disp_detail_sched?term_in=${term}&crn_in=${section.crn}`,
         },
         {
           icon: faBan,


### PR DESCRIPTION
### Summary
Updated the hyperlinks 

### How to Test
Run gt-scheduler locally and add a class section. Then, click on the seats button for each section. Ensure that the OSCAR tab opened has the correct term and the class section matches the one in gt-scheduler. 