### PR TITLE
Fix mobile course container overflow issue

### DIFF
--- a/src/components/CourseContainer/stylesheet.scss
+++ b/src/components/CourseContainer/stylesheet.scss
@@ -28,7 +28,7 @@
 
   .updated-at {
     color: $color-neutral;
-    font-size: .8em;
+    font-size: 0.8em;
   }
 }
 
@@ -37,6 +37,6 @@
   border-right: none;
 
   .scroller {
-    width: auto;
+    width: 100vw;
   }
 }


### PR DESCRIPTION
Resolves #225 

### Summary

Fixes issue where course container width overflows off the screen on mobile for long course names.

### How to Test
Add a course with a long course name (VIP 3602 is an example) on mobile and check if there are any issues