### PR TITLE
Fix Exported Calendar Does Not Account for Local Timezone

### DIFF
--- a/src/utils/misc.tsx
+++ b/src/utils/misc.tsx
@@ -279,6 +279,9 @@ const getDateRange = (term: string): DateRange => {
   return { from, to };
 };
 
+// Difference between UTC and EST timezones in minutes
+export const EST_TIMEZONE_OFFSET = 240;
+
 /**
  * Exports the current schedule to a `.ics` file,
  * which allows for importing into a third-party calendar application.
@@ -302,6 +305,8 @@ export function exportCoursesToCalendar(
     return;
   }
 
+  const timezoneDiff = EST_TIMEZONE_OFFSET - new Date().getTimezoneOffset();
+
   const addEventsToCalendar = (
     period: Period,
     days: string[],
@@ -317,9 +322,11 @@ export function exportCoursesToCalendar(
     ) {
       begin.setDate(begin.getDate() + 1);
     }
-    begin.setHours(period.start / 60, period.start % 60);
+    const startWithOffset = period.start + timezoneDiff;
+    const endWithOffset = period.end + timezoneDiff;
+    begin.setHours(startWithOffset / 60, startWithOffset % 60);
     const end = new Date(begin.getTime());
-    end.setHours(period.end / 60, period.end % 60);
+    end.setHours(endWithOffset / 60, endWithOffset % 60);
     const rrule = {
       freq: 'WEEKLY',
       until: to,


### PR DESCRIPTION
### Summary

Resolves #129 

The `ics` module does not have a Timezone field. If students were to export their calendar from a timezone other than EST, the exported calendar would not offset the section times based on the timezone difference. Eg: If a user exported their calendar in California, a section with time 2:00 PM - 3:30 PM EST would show up as 2:00 PM - 3:30 PM in the exported calendar instead of 11:00 PM - 12:30 PM. The fix would especially help students studying abroad or registering from other time zones.

### Checklist

- [x] Offset the section times based on the time difference between the local timezone and EST.

### How to Test
Follow the steps mentioned by the user in their issue #129 