### PR TITLE
consume and show section specific titles

### DIFF
--- a/src/components/SectionBlocks/index.tsx
+++ b/src/components/SectionBlocks/index.tsx
@@ -90,7 +90,7 @@ export default function SectionBlocks({
             popover={[
               {
                 name: 'Course Name',
-                content: section.course.title,
+                content: section.title,
               },
               {
                 name: 'Instructors',

--- a/src/data/beans/Section.ts
+++ b/src/data/beans/Section.ts
@@ -30,7 +30,8 @@ type SectionConstructionData = [
   scheduleTypeIndex: number,
   campusIndex: number,
   attributeIndices: number[],
-  gradeBasisIndex: number
+  gradeBasisIndex: number,
+  title: string
 ];
 
 export default class Section {
@@ -39,6 +40,8 @@ export default class Section {
   id: string;
 
   crn: string;
+
+  title: string;
 
   seating: Seating;
 
@@ -79,11 +82,13 @@ export default class Section {
       campusIndex,
       attributeIndices,
       gradeBasisIndex,
+      title,
     ] = data;
 
     this.course = course;
     this.id = sectionId;
     this.crn = crn;
+    this.title = decode(title);
     this.seating = [[], 0];
     this.credits = credits;
     this.scheduleType = oscar.scheduleTypes[scheduleTypeIndex] ?? 'unknown';

--- a/src/types.ts
+++ b/src/types.ts
@@ -184,7 +184,12 @@ export type CrawlerSection = [
    * integer index into caches.gradeBases,
    * specifying the grading scheme of the class
    */
-  gradeBaseIndex: number
+  gradeBaseIndex: number,
+  /**
+   * the full, human-readable name of the section (e.g. "Accounting I"),
+   * since sections within the same course can have different names
+   */
+  fullName: string
 ];
 
 // Prerequisite types:
@@ -287,7 +292,9 @@ export interface CrawlerCaches {
  */
 export type CrawlerCourse = [
   /**
-   * the full, human-readable name of the course (e.g. "Accounting I")
+   * the full, human-readable name of the course (e.g. "Accounting I"),
+   * (**Note** that this is simply the title of the first section added to
+   * sections)
    */
   fullName: string,
   /**


### PR DESCRIPTION
### Summary

No ticket related.

I noticed for CS 8803 the section title shown was not the sections actual title, it was whatever the first section for CS 8803's title was, which happened to be Computer Law or something.
![image](https://github.com/gt-scheduler/crawler-v2/assets/61996677/ead05904-b087-4e2e-be54-548088eca03b)

This is because the code only tracks a single title for the course itself, not specific sections. This PR adds that data to the crawler's section type.

Note: I had to add the extra field at the end of the tuple type for compatibility with GT scheduler's frontend parsing because tuples are parsed by their order, not the names of their field. This means you *should* be able to roll the backend PR first https://github.com/gt-scheduler/crawler-v2/pull/18, then roll this PR to change the frontend. As a side-note, I think this is the disadvantage of using tuples, if these were records, it would likely be easier to upgrade the types.

This is what the final product looks like after both backend and frontend roll:
![image](https://github.com/gt-scheduler/crawler-v2/assets/61996677/fb245f63-8de8-4b6d-a9d0-a465505ba9bb)

Potential Future Work:
- You can see on the left pane it still just uses the first section's title for the title of the CS 8803 panel, but... I don't know what else you'd put there, ideally the words "Special Topics" would go there, but I'm not sure where that info is generally available. Regardless, this PR is an improvement.
- Deprecate  the usage of `course.title` to use the first section's title, so that you can later remove `course.title` in the backend afterward.

### Checklist

yarn lint and format

### How to Test
Look at an example like CS 8803.