### PR TITLE
Fixed draggable block realignment

### DIFF
--- a/src/components/EventBlocks/index.tsx
+++ b/src/components/EventBlocks/index.tsx
@@ -90,6 +90,14 @@ export default function EventBlocks({
       ref.current.parentNode?.appendChild(cloneMeeting);
       ref.current.classList.add('meeting--dragging');
       ref.current.style.width = '20%';
+
+      // Align to the block to the start of the day column
+      const oldLeftPercentValue = parseFloat(ref.current.style.left);
+      if (!Number.isNaN(oldLeftPercentValue)) {
+        ref.current.style.left = `${
+          Math.floor(oldLeftPercentValue / 20) * 20
+        }%`;
+      }
     }
 
     // Disabled eslint because it doesn't like the parameter


### PR DESCRIPTION
### Summary

Fixed realignment of draggable event block on mouse press-down event (see issue #250). The new CSS '`left` property is calculated by rounding down the current block ref's `left` property into a multiple of 20%.

### How to Test
1. Add a course or event to the calendar.
2. Add a recurring event that lasts longer than the meeting added in Step 1 and is in conflict with one of its days.
3. Click down on the longer event (but don't move your mouse)
4. The draggable block should be aligned on the left side of the day column.

![image](https://github.com/gt-scheduler/website/assets/105668049/3ea408b1-bcd5-4973-86f9-b291f6a9cf9a)
