### PR TITLE
Emily/229 reintroduce link to course section

### DIFF
--- a/src/components/Prerequisite/index.tsx
+++ b/src/components/Prerequisite/index.tsx
@@ -1,6 +1,11 @@
-import React, { useState } from 'react';
-import { faAngleUp, faAngleDown } from '@fortawesome/free-solid-svg-icons';
+import React, { useState, useContext } from 'react';
+import {
+  faAngleUp,
+  faAngleDown,
+  faInfoCircle,
+} from '@fortawesome/free-solid-svg-icons';
 
+import { ScheduleContext } from '../../contexts';
 import { classes, serializePrereqs } from '../../utils/misc';
 import { ActionRow } from '..';
 import { Course } from '../../data/beans';
@@ -83,12 +88,22 @@ export default function Prerequisite({
     }
   }
 
+  const [{ term }] = useContext(ScheduleContext);
+
   return (
     <div className={classes('hover-container', 'nested')}>
       <ActionRow
         className={classes('hover-container')}
         label="Prerequisites"
-        actions={[]}
+        actions={[
+          {
+            icon: faInfoCircle,
+            href:
+              `https://oscar.gatech.edu/pls/bprod/bwckctlg.p_disp_` +
+              `course_detail?cat_term_in=${term}&subj_code_in=` +
+              `${course.subject}&crse_numb_in=${course.number}`,
+          },
+        ]}
       />
       <div className={classes('nested')}>{content}</div>
     </div>

--- a/src/components/Section/index.tsx
+++ b/src/components/Section/index.tsx
@@ -100,6 +100,7 @@ export default function Section({
         {
           icon: faChair,
           id: sectionTooltipId,
+          href: `https://oscar.gatech.edu/pls/bprod/bwckschd.p_disp_detail_sched?term_in=${term}&crn_in=${section.crn}`,
         },
         {
           icon: faBan,


### PR DESCRIPTION
### Summary

Updated PR for #234 on behalf of @EmilyAL001 
Resolves #229 

<!-- What does this PR change and why? Discuss any breaking changes. -->

Links seat icon to section seats info page and adds back in prerequisites info button that links to section info page

### Checklist

- [ ] Status quo is reverted :>

### How to Test
<!-- Describe how to test your code. -->
Click on the seat icon on any course section to be taken to the info page
Click on the info button in the prerequisites section to be taken to the info page