### PR TITLE
Fix Mobile Course Container Overflow Issue

### DIFF
--- a/src/components/CourseContainer/stylesheet.scss
+++ b/src/components/CourseContainer/stylesheet.scss
@@ -37,6 +37,6 @@
   border-right: none;
 
   .scroller {
-    width: auto;
+    width: 100vw;
   }
 }


### PR DESCRIPTION
This is an updated PR for #226 on behalf of @nathangong 

### Summary

Fixes issue where course container width overflows off the screen on mobile for long course names.

### How to Test
Add a course with a long course name (VIP 3602 is an example) on mobile and check if there are any issues