### PR TITLE
Compare Panel UI changes

### DIFF
--- a/src/components/ComparisonContainer/index.tsx
+++ b/src/components/ComparisonContainer/index.tsx
@@ -307,7 +307,7 @@ export default function ComparisonContainer({
               })}
           </div>
           <div className="shared-schedules">
-            <p className="content-title">Shared with me</p>
+            <p className="content-title shared-with">Shared with me</p>
             {Object.keys(friends).length !== 0 ? (
               Object.entries(friends).map(([friendId, friend]) => {
                 return (
@@ -486,7 +486,11 @@ function ScheduleRow({
   return (
     <div className="schedule-row">
       <div
-        className={classes('checkbox-container', edit && 'editing')}
+        className={classes(
+          'checkbox-container',
+          edit && 'editing',
+          type === 'Schedule' && 'schedule-checkbox'
+        )}
         onMouseEnter={(): void => setDivHover(true)}
         onMouseLeave={(): void => setDivHover(false)}
       >
@@ -515,7 +519,12 @@ function ScheduleRow({
               onMouseEnter={(): void => setTooltipHover(true)}
               onMouseLeave={(): void => setTooltipHover(false)}
             >
-              <div className={classes(type === 'User' && 'friend-name')}>
+              <div
+                className={classes(
+                  type === 'User' && 'friend-name',
+                  checkboxColor !== '' && 'checked'
+                )}
+              >
                 <p>{name}</p>
               </div>
               {hasTooltip && email !== name && (

--- a/src/components/ComparisonContainer/index.tsx
+++ b/src/components/ComparisonContainer/index.tsx
@@ -342,6 +342,9 @@ export default function ComparisonContainer({
                       setEditInfo={setEditInfo}
                       editValue={editValue}
                     />
+                    <div className="friend-email">
+                      <p>{friend.email}</p>
+                    </div>
                     {Object.entries(friend.versions).map(
                       ([scheduleId, schedule]) => {
                         return (
@@ -512,7 +515,9 @@ function ScheduleRow({
               onMouseEnter={(): void => setTooltipHover(true)}
               onMouseLeave={(): void => setTooltipHover(false)}
             >
-              <p>{name}</p>
+              <div className={classes(type === 'User' && 'friend-name')}>
+                <p>{name}</p>
+              </div>
               {hasTooltip && email !== name && (
                 <ReactTooltip
                   key={id}

--- a/src/components/ComparisonContainer/stylesheet.scss
+++ b/src/components/ComparisonContainer/stylesheet.scss
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap');
 @import '../../variables';
 
 .comparison-container {
@@ -17,15 +18,21 @@
       p {
         margin: 0px;
         overflow: hidden;
-        font-size: 12px;
-        font-weight: 500;
-        line-height: 14px;
+        font-size: 14px;
+        font-weight: 400;
+        line-height: normal;
+        font-family: Roboto;
 
         &.content-title{
           font-weight: 700;
           margin: 16px 12px 4px 12px;
           border-bottom: 1px solid $color-border;
         }
+
+        &.shared-with{
+          margin-bottom: 6px;
+        }
+
       }
 
       .friend-email {
@@ -37,10 +44,16 @@
         }
       }
 
+      .checked {
+        p{
+          font-weight: 700;
+        }
+      }
+
       .friend-name {
         p {
           font-weight: 700;
-          font-size: 14px;
+          font-size: 16px;
         }
       }
 
@@ -67,6 +80,7 @@
           height: 22px;
           
           .checkbox {
+            
             margin-left: 12px;
             border: 1px solid;
             border-radius: 3px;
@@ -74,8 +88,8 @@
             transition-duration: $theme-switch-transition-duration;
             transition-property: border-color;
 
-            width: 11px;
-            height: 11px;
+            width: 12px;
+            height: 12px;
 
             &:hover {
               cursor: pointer;
@@ -151,6 +165,12 @@
               opacity: 1;
             }
           }
+
+          &.schedule-checkbox {
+            margin-top: 8px;
+            margin-bottom: 8px;
+          }
+
         }
 
         .palette {

--- a/src/components/ComparisonContainer/stylesheet.scss
+++ b/src/components/ComparisonContainer/stylesheet.scss
@@ -28,6 +28,22 @@
         }
       }
 
+      .friend-email {
+        display: flex;
+        align-items: center;
+        p {
+          padding: 0px 2px 2px 12px;
+          text-align: center;
+        }
+      }
+
+      .friend-name {
+        p {
+          font-weight: 700;
+          font-size: 14px;
+        }
+      }
+
       .no-shared-schedules {
         margin: 8px 12px;
 

--- a/src/components/ComparisonPanel/index.tsx
+++ b/src/components/ComparisonPanel/index.tsx
@@ -1,10 +1,13 @@
 import React, { useState, useContext, useId, useCallback } from 'react';
 import { Tooltip as ReactTooltip } from 'react-tooltip';
+import { faShare } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { CombinationContainer, ComparisonContainer } from '..';
 import { AccountContext } from '../../contexts/account';
 import { classes } from '../../utils/misc';
 import Modal from '../Modal';
+import InvitationModal from '../InvitationModal';
 
 import './stylesheet.scss';
 
@@ -28,9 +31,13 @@ export default function ComparisonPanel({
   const [tooltipY, setTooltipY] = useState(0);
   const [signedInModal, setSignedInModal] = useState(false);
   const [compare, setCompare] = useState(false);
+  const [invitationOpen, setInvitationOpen] = useState(false);
   // const [hoverCompare, setHoverCompare] = useState(false);
   // const [tooltipYCompare, setTooltipYCompare] = useState(0);
   const tooltipId = useId();
+
+  const openInvitation = useCallback(() => setInvitationOpen(true), []);
+  const hideInvitation = useCallback(() => setInvitationOpen(false), []);
 
   const { type } = useContext(AccountContext);
 
@@ -98,11 +105,25 @@ export default function ComparisonPanel({
           </label>
         </div>
         {compare && (
-          <ComparisonContainer
-            handleCompareSchedules={handleCompareSchedules}
-            pinnedSchedules={pinnedSchedules}
-            pinSelf={pinSelf}
-          />
+          <div>
+            <InvitationModal show={invitationOpen} onHide={hideInvitation} />
+            <div className="invite-panel">
+              <button
+                type="button"
+                onClick={openInvitation}
+                className="invite-button"
+                disabled={type === 'signedOut'}
+              >
+                <FontAwesomeIcon fixedWidth icon={faShare} />
+                <div>Share Schedule</div>
+              </button>
+            </div>
+            <ComparisonContainer
+              handleCompareSchedules={handleCompareSchedules}
+              pinnedSchedules={pinnedSchedules}
+              pinSelf={pinSelf}
+            />
+          </div>
         )}
         <div className="combination">
           <CombinationContainer compare={compare} />

--- a/src/components/ComparisonPanel/index.tsx
+++ b/src/components/ComparisonPanel/index.tsx
@@ -91,6 +91,18 @@ export default function ComparisonPanel({
         </ReactTooltip>
       </div>
       <div className={classes('panel', !expanded && 'closed')}>
+        <InvitationModal show={invitationOpen} onHide={hideInvitation} />
+        <div className="invite-panel">
+          <button
+            type="button"
+            onClick={openInvitation}
+            className="invite-button"
+            disabled={type === 'signedOut'}
+          >
+            <FontAwesomeIcon fixedWidth icon={faShare} />
+            <div>Share Schedule</div>
+          </button>
+        </div>
         <div className="comparison-header">
           <p className="header-title">Compare Schedules</p>
           <p className="header-text">{compare ? 'On' : 'Off'}</p>
@@ -106,18 +118,6 @@ export default function ComparisonPanel({
         </div>
         {compare && (
           <div>
-            <InvitationModal show={invitationOpen} onHide={hideInvitation} />
-            <div className="invite-panel">
-              <button
-                type="button"
-                onClick={openInvitation}
-                className="invite-button"
-                disabled={type === 'signedOut'}
-              >
-                <FontAwesomeIcon fixedWidth icon={faShare} />
-                <div>Share Schedule</div>
-              </button>
-            </div>
             <ComparisonContainer
               handleCompareSchedules={handleCompareSchedules}
               pinnedSchedules={pinnedSchedules}

--- a/src/components/ComparisonPanel/stylesheet.scss
+++ b/src/components/ComparisonPanel/stylesheet.scss
@@ -134,6 +134,27 @@
       }
     }
 
+    .invite-panel {
+      align-items: center;
+      display: flex;
+      margin: 8px 10px 1px 20px;
+      .invite-button {
+        align-items: center;
+        font-size: 14px;
+        color: white;
+        border-radius: 9px;
+        background-color: #676767;
+        display: flex;
+        padding: 10px 50px 10px 50px;
+        border: none;
+  
+        &:hover {
+          background-color: #929292;
+        }
+      }
+    }
+
+
     .comparison-overlay {
       background-color: var(--theme-bg);
   

--- a/src/components/ComparisonPanel/stylesheet.scss
+++ b/src/components/ComparisonPanel/stylesheet.scss
@@ -192,7 +192,7 @@
   }
   .invite-panel {
     display: flex;
-    margin: 10px 10px 1px 16px;
+    margin: 10px 10px 10px 16px;
     .invite-button {
       align-items: center;
       font-size: 14px;

--- a/src/components/ComparisonPanel/stylesheet.scss
+++ b/src/components/ComparisonPanel/stylesheet.scss
@@ -134,27 +134,6 @@
       }
     }
 
-    .invite-panel {
-      align-items: center;
-      display: flex;
-      margin: 8px 10px 1px 20px;
-      .invite-button {
-        align-items: center;
-        font-size: 14px;
-        color: white;
-        border-radius: 9px;
-        background-color: #676767;
-        display: flex;
-        padding: 10px 50px 10px 50px;
-        border: none;
-  
-        &:hover {
-          background-color: #929292;
-        }
-      }
-    }
-
-
     .comparison-overlay {
       background-color: var(--theme-bg);
   
@@ -211,4 +190,25 @@
       }
     }
   }
+  .invite-panel {
+    display: flex;
+    margin: 10px 10px 1px 16px;
+    .invite-button {
+      align-items: center;
+      font-size: 14px;
+      font-weight: 500;
+      color: white;
+      border-radius: 10px;
+      background-color: #676767;
+      display: flex;
+      padding: 10px 50px 10px 50px;
+      border: none;
+      gap: 5px;
+
+      &:hover {
+        background-color: #929292;
+      }
+    }
+  }
+
 }

--- a/src/components/HeaderActionBar/index.tsx
+++ b/src/components/HeaderActionBar/index.tsx
@@ -4,12 +4,9 @@ import {
   faCalendarAlt,
   faPaste,
   faCaretDown,
-  faShare,
-  faCircle,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import React, { useCallback, useContext, useState } from 'react';
-import useLocalStorageState from 'use-local-storage-state';
+import React from 'react';
 
 import { Button } from '..';
 import {
@@ -17,11 +14,10 @@ import {
   LARGE_DESKTOP_BREAKPOINT,
 } from '../../constants';
 import useMedia from '../../hooks/useMedia';
-import { AccountContext, AccountContextValue } from '../../contexts/account';
+import { AccountContextValue } from '../../contexts/account';
 import { classes } from '../../utils/misc';
 import { DropdownMenu, DropdownMenuAction } from '../Select';
 import AccountDropdown from '../AccountDropdown';
-import InvitationModal from '../InvitationModal';
 import ShareIcon from '../ShareIcon';
 
 import './stylesheet.scss';
@@ -37,9 +33,6 @@ export type HeaderActionBarProps = {
   onDownloadCalendar?: () => void;
   enableDownloadCalendar?: boolean;
 };
-
-// Key to mark when a user has already seen the invite modal.
-const MODAL_LOCAL_STORAGE_KEY = '2023-05-10-spr2023-invite-modal';
 
 /**
  * Displays the icon buttons (with optional text)
@@ -59,25 +52,6 @@ export default function HeaderActionBar({
   onDownloadCalendar = (): void => undefined,
   enableDownloadCalendar = false,
 }: HeaderActionBarProps): React.ReactElement {
-  const { type } = useContext(AccountContext);
-
-  const [invitationOpen, setInvitationOpen] = useState(false);
-  const [seenInviteModal, setSeenInviteModal] = useLocalStorageState<boolean>(
-    MODAL_LOCAL_STORAGE_KEY,
-    {
-      defaultValue: false,
-      storageSync: true,
-    }
-  );
-
-  const openInvitation = useCallback(() => {
-    setInvitationOpen(true);
-    if (!seenInviteModal) {
-      setSeenInviteModal(true);
-    }
-  }, [seenInviteModal, setSeenInviteModal]);
-  const hideInvitation = useCallback(() => setInvitationOpen(false), []);
-
   // Coalesce the export options into the props for a single <DropdownMenu>
   const enableExport =
     enableCopyCrns || enableDownloadCalendar || enableExportCalendar;
@@ -127,23 +101,6 @@ export default function HeaderActionBar({
           <FontAwesomeIcon fixedWidth icon={faCaretDown} />
         </div>
       </DropdownMenu>
-      <InvitationModal show={invitationOpen} onHide={hideInvitation} />
-
-      <Button
-        onClick={openInvitation}
-        disabled={type === 'signedOut'}
-        className={classes('header-action-bar__button', 'invite-button')}
-      >
-        <FontAwesomeIcon
-          className="header-action-bar__button-icon"
-          fixedWidth
-          icon={faShare}
-        />
-        <div className="header-action-bar__button-text">Invite</div>
-        {seenInviteModal || type === 'signedOut' ? null : (
-          <FontAwesomeIcon className="circle" fixedWidth icon={faCircle} />
-        )}
-      </Button>
 
       <Button
         href="https://github.com/gt-scheduler/website"

--- a/src/components/HeaderActionBar/stylesheet.scss
+++ b/src/components/HeaderActionBar/stylesheet.scss
@@ -5,14 +5,6 @@
   align-items: stretch;
   justify-content: flex-end;
 
-  .invite-button {
-    .circle {   
-      margin: 4px 0px 0px 8px;
-      width: 8px;
-      color: #FF7337;
-    }
-  }
-
   @media (max-width: $desktop-breakpoint) {
     flex: 1;
     margin-left: 0;


### PR DESCRIPTION
### Summary

Resolves #285

Moved invite button from Header to Compare Panel, added displaying email alongside name for users shared with

### Checklist

- [x] Move the invite button from the Header component to the Compare Panel component and style according to figma.
- [x] Instead of displaying just the editable name of the friends in the comparison panel, display both name and emails like in the image above and the figma.
- [x] Modify the font size and match styling of the compare panel to the figma prototype .


### How to Test
Access Share Schedule feature