### PR TITLE
Share schedule back feature

### DIFF
--- a/src/components/ComparisonContainer/index.tsx
+++ b/src/components/ComparisonContainer/index.tsx
@@ -30,6 +30,7 @@ import { ErrorWithFields, softError } from '../../log';
 import { CLOUD_FUNCTION_BASE_URL } from '../../constants';
 
 import './stylesheet.scss';
+import InvitationModal from '../InvitationModal';
 
 export type SharedSchedule = {
   email: string;
@@ -76,9 +77,10 @@ export default function ComparisonContainer({
   const [editValue, setEditValue] = useState('');
   const [paletteInfo, setPaletteInfo] = useState<string>();
   const [scheduleSelected, setScheduleSelected] = useState(pinSelf);
+  const [invitationOpen, setInvitationOpen] = useState(false);
 
   const [
-    { allVersionNames, currentVersion, colorMap, term },
+    { currentFriends, allVersionNames, currentVersion, colorMap, term },
     { deleteVersion, renameVersion, patchSchedule },
   ] = useContext(ScheduleContext);
 
@@ -248,6 +250,20 @@ export default function ComparisonContainer({
     [colorMap, patchSchedule]
   );
 
+  const findNotShared = useCallback(() => {
+    const currentFriendEmails = Object.values(currentFriends).map(
+      (friend) => friend.email
+    );
+    const friendEmails = Object.values(friends).map((friend) => friend.email);
+    const notShared = friendEmails.filter(
+      (email) => !currentFriendEmails.includes(email)
+    );
+    return notShared;
+  }, [currentFriends, friends]);
+
+  const openInvitation = useCallback(() => setInvitationOpen(true), []);
+  const hideInvitation = useCallback(() => setInvitationOpen(false), []);
+
   return (
     <div className="comparison-container">
       <div className="comparison-body">
@@ -388,6 +404,37 @@ export default function ComparisonContainer({
                         );
                       }
                     )}
+                    {findNotShared().indexOf(friend.email) > -1 ? (
+                      <div className="shareback-panel">
+                        <div>
+                          <p>
+                            You have {friend.name}&apos;s schedule. Would you
+                            like to share yours back?
+                          </p>
+                        </div>
+                        <div>
+                          <button
+                            type="button"
+                            className="dont-shareback-button"
+                          >
+                            Don&apos;t Share
+                          </button>
+
+                          <button
+                            type="button"
+                            className="shareback-button"
+                            onClick={openInvitation}
+                          >
+                            Share
+                          </button>
+                        </div>
+                        <InvitationModal
+                          show={invitationOpen}
+                          onHide={hideInvitation}
+                          inputEmail={friend.email}
+                        />
+                      </div>
+                    ) : null}
                   </div>
                 );
               })

--- a/src/components/ComparisonContainer/index.tsx
+++ b/src/components/ComparisonContainer/index.tsx
@@ -28,9 +28,9 @@ import { AutoFocusInput } from '../Select';
 import { Palette } from '..';
 import { ErrorWithFields, softError } from '../../log';
 import { CLOUD_FUNCTION_BASE_URL } from '../../constants';
+import InvitationModal from '../InvitationModal';
 
 import './stylesheet.scss';
-import InvitationModal from '../InvitationModal';
 
 export type SharedSchedule = {
   email: string;

--- a/src/components/ComparisonContainer/stylesheet.scss
+++ b/src/components/ComparisonContainer/stylesheet.scss
@@ -34,6 +34,10 @@
 
       }
 
+      .friend {
+        padding-bottom: 10px;
+      }
+
       .friend-email {
         display: flex;
         align-items: center;
@@ -185,19 +189,18 @@
 
       .shareback-panel {
         display: flex;
-        width: 233px;
-        height: 70px;
         flex-direction: column;
         align-items: center;
         margin-top: 12px;
         margin-left: 10px;
+        margin-right: 10px;
         border: 1px solid #7C7C7C;
         border-radius: 8px;
         padding: 8px 10px;
         gap: 6px;
         
         p {
-          font-size: 10px;
+          font-size: 12px;
           line-height: normal;
         }
       
@@ -205,7 +208,7 @@
           width: 100px;
           height: 24px;
           padding: 6px 10px;
-          font-size: 10px;
+          font-size: 12px;
           color: #000000;
           border-radius: 8px;
           background-color: #FFF;
@@ -221,7 +224,7 @@
           width: 100px;
           height: 24px;
           padding: 6px 10px;
-          font-size: 10px;
+          font-size: 12px;
           color: white;
           border-radius: 8px;
           background-color: #333;

--- a/src/components/ComparisonContainer/stylesheet.scss
+++ b/src/components/ComparisonContainer/stylesheet.scss
@@ -4,7 +4,6 @@
   .comparison-body {
     display: flex;
     flex-direction: column;
-    white-space: nowrap;
     height: 100%;
 
     .comparison-content {
@@ -144,6 +143,57 @@
           overflow: hidden;
           &.indented {
             margin-left: 24px;
+          }
+        }
+      }
+
+      .shareback-panel {
+        display: flex;
+        width: 233px;
+        height: 70px;
+        flex-direction: column;
+        align-items: center;
+        margin-top: 12px;
+        margin-left: 10px;
+        border: 1px solid #7C7C7C;
+        border-radius: 8px;
+        padding: 8px 10px;
+        gap: 6px;
+        
+        p {
+          font-size: 10px;
+          line-height: normal;
+        }
+      
+        .shareback-button {
+          width: 100px;
+          height: 24px;
+          padding: 6px 10px;
+          font-size: 10px;
+          color: #000000;
+          border-radius: 8px;
+          background-color: #FFF;
+          border: 1px solid #7C7C7C;
+          margin-left: 5px;
+      
+          &:hover {
+            background-color: #d1d1d1;
+          }
+        }
+      
+        .dont-shareback-button {
+          width: 100px;
+          height: 24px;
+          padding: 6px 10px;
+          font-size: 10px;
+          color: white;
+          border-radius: 8px;
+          background-color: #333;
+          border: 1px solid #7C7C7C;
+          margin-right: 5px;
+      
+          &:hover {
+            background-color: #7C7C7C;
           }
         }
       }

--- a/src/components/ComparisonContainerShareBack/ComparisonContainerShareBack.tsx
+++ b/src/components/ComparisonContainerShareBack/ComparisonContainerShareBack.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import useLocalStorageState from 'use-local-storage-state';
+
+type ComparisonContainerShareBack = {
+  friendId: string;
+  friendName: string;
+  friendEmail: string;
+  setModalEmail: React.Dispatch<React.SetStateAction<string>>;
+  setModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+export default function ComparisonContainerShareBack({
+  friendName,
+  friendEmail,
+  friendId,
+  setModalEmail,
+  setModalOpen,
+}: ComparisonContainerShareBack): React.ReactElement | null {
+  const [hasSeen, setHasSeen] = useLocalStorageState(
+    `share-back-invitation-${friendId}`,
+    {
+      defaultValue: false,
+      storageSync: true,
+    }
+  );
+
+  if (hasSeen) {
+    return null;
+  }
+
+  return (
+    <div className="shareback-panel">
+      <div>
+        <p>
+          You have {friendName}&apos;s schedule. Would you like to share yours
+          back?
+        </p>
+      </div>
+      <div>
+        <button
+          type="button"
+          className="dont-shareback-button"
+          onClick={(): void => {
+            setHasSeen(true);
+          }}
+        >
+          Don&apos;t Share
+        </button>
+
+        <button
+          type="button"
+          className="shareback-button"
+          onClick={(): void => {
+            setHasSeen(true);
+            setModalEmail(friendEmail);
+            setModalOpen(true);
+          }}
+        >
+          Share
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/InvitationModal/index.tsx
+++ b/src/components/InvitationModal/index.tsx
@@ -26,7 +26,13 @@ import './stylesheet.scss';
 /**
  * Inner content of the invitation modal.
  */
-export function InvitationModalContent(): React.ReactElement {
+export type InvitationModalContentProps = {
+  inputEmail?: string;
+};
+
+export function InvitationModalContent({
+  inputEmail,
+}: InvitationModalContentProps): React.ReactElement {
   const [removeInvitationOpen, setRemoveInvitationOpen] = useState(false);
   const [currentFriendId, setCurrentFriendId] = useState('');
 
@@ -38,16 +44,21 @@ export function InvitationModalContent(): React.ReactElement {
   const input = useRef<HTMLInputElement>(null);
   const [validMessage, setValidMessage] = useState('');
   const [validClassName, setValidClassName] = useState('');
+  const [emailInput, setEmailInput] = useState(inputEmail ?? '');
 
   const redirectURL = useMemo(
     () => window.location.href.split('/#')[0] ?? '/',
     []
   );
 
-  const handleChangeSearch = useCallback(() => {
-    setValidMessage('');
-    setValidClassName('');
-  }, []);
+  const handleChangeSearch = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setEmailInput(e.target.value);
+      setValidMessage('');
+      setValidClassName('');
+    },
+    [emailInput, setEmailInput]
+  );
 
   const sendInvitation = useCallback(async (): Promise<void> => {
     const IdToken = await (accountContext as SignedIn).getToken();
@@ -197,6 +208,7 @@ export function InvitationModalContent(): React.ReactElement {
               onFocus={handleChangeSearch}
               onKeyDown={handleKeyDown}
               onChange={handleChangeSearch}
+              value={emailInput}
             />
             <text className={validClassName}>{validMessage}</text>
           </div>
@@ -283,6 +295,7 @@ export function RemoveInvitationModalContent({
 export type InvitationModalProps = {
   show: boolean;
   onHide: () => void;
+  inputEmail?: string;
 };
 
 /**
@@ -291,6 +304,7 @@ export type InvitationModalProps = {
 export default function InvitationModal({
   show,
   onHide,
+  inputEmail,
 }: InvitationModalProps): React.ReactElement {
   return (
     <Modal
@@ -303,7 +317,7 @@ export default function InvitationModal({
       <Button className="remove-close-button" onClick={onHide}>
         <FontAwesomeIcon icon={faXmark} size="xl" />
       </Button>
-      <InvitationModalContent />
+      <InvitationModalContent inputEmail={inputEmail} />
     </Modal>
   );
 }

--- a/src/components/InvitationModal/index.tsx
+++ b/src/components/InvitationModal/index.tsx
@@ -57,7 +57,7 @@ export function InvitationModalContent({
       setValidMessage('');
       setValidClassName('');
     },
-    [emailInput, setEmailInput]
+    [setEmailInput]
   );
 
   const sendInvitation = useCallback(async (): Promise<void> => {

--- a/src/data/hooks/useFirebaseAuth.ts
+++ b/src/data/hooks/useFirebaseAuth.ts
@@ -50,7 +50,7 @@ export default function useFirebaseAuth(): LoadingState<AccountContextValue> {
                 .signOut()
                 .then(() => {
                   // don't want to share localStorage between accounts
-                  localStorage.clear()
+                  localStorage.clear();
                 })
                 .catch((err) => {
                   softError(

--- a/src/data/hooks/useFirebaseAuth.ts
+++ b/src/data/hooks/useFirebaseAuth.ts
@@ -48,6 +48,10 @@ export default function useFirebaseAuth(): LoadingState<AccountContextValue> {
               firebase
                 .auth()
                 .signOut()
+                .then(() => {
+                  // don't want to share localStorage between accounts
+                  localStorage.clear()
+                })
                 .catch((err) => {
                   softError(
                     new ErrorWithFields({


### PR DESCRIPTION
### Summary

Resolves #284 

 added functionality to the UI for sharing back schedules to friends that the user has schedules of

### Checklist

- [x] Extract the reference passed to the input div of the modal and store in the component which will trigger the modal instead. Whenever the user clicks share back, we will pass in the email of the friend that they're trying to share their schedule with to the modal using the ref that we extracted. This is a suggestion, feel free to use other solutions which fulfill this goal. When the invitation modal opens, it will have the email of the friend already input in the box and they will just have to press send.
- [x] Create the UI elements as displayed in the figma prototype. However instead of only having one of the share back options at a time as shown in the pictures above, have both of them displayed at all times for now.


### How to Test
Open compare schedules with friends not shared with