### PR TITLE
Brandon/293 share schedule UI changes

### DIFF
--- a/src/components/ComparisonPanel/index.tsx
+++ b/src/components/ComparisonPanel/index.tsx
@@ -8,6 +8,7 @@ import { AccountContext } from '../../contexts/account';
 import { classes } from '../../utils/misc';
 import Modal from '../Modal';
 import InvitationModal from '../InvitationModal';
+import LoginModal from '../LoginModal';
 
 import './stylesheet.scss';
 
@@ -29,14 +30,14 @@ export default function ComparisonPanel({
   const [expanded, setExpanded] = useState(true);
   const [hover, setHover] = useState(false);
   const [tooltipY, setTooltipY] = useState(0);
-  const [signedInModal, setSignedInModal] = useState(false);
   const [compare, setCompare] = useState(false);
   const [invitationOpen, setInvitationOpen] = useState(false);
   // const [hoverCompare, setHoverCompare] = useState(false);
   // const [tooltipYCompare, setTooltipYCompare] = useState(0);
   const tooltipId = useId();
+  const [loginOpen, setLoginOpen] = useState(false);
+  const hideLogin = useCallback(() => setLoginOpen(false), []);
 
-  const openInvitation = useCallback(() => setInvitationOpen(true), []);
   const hideInvitation = useCallback(() => setInvitationOpen(false), []);
 
   const { type } = useContext(AccountContext);
@@ -46,12 +47,20 @@ export default function ComparisonPanel({
     setTooltipY(e.clientY);
   }, []);
 
+  const handleOpenInvitation = useCallback(() => {
+    if (type === 'signedIn') {
+      setInvitationOpen(true);
+    } else {
+      setLoginOpen(true);
+    }
+  }, [type]);
+
   const handleTogglePanel = useCallback(() => {
     if (type === 'signedIn') {
       setCompare(!compare);
       handleCompareSchedules(!compare, undefined, undefined);
     } else {
-      setSignedInModal(true);
+      setLoginOpen(true);
     }
   }, [type, compare, handleCompareSchedules]);
 
@@ -95,9 +104,8 @@ export default function ComparisonPanel({
         <div className="invite-panel">
           <button
             type="button"
-            onClick={openInvitation}
+            onClick={handleOpenInvitation}
             className="invite-button"
-            disabled={type === 'signedOut'}
           >
             <FontAwesomeIcon fixedWidth icon={faShare} />
             <div>Share Schedule</div>
@@ -155,24 +163,7 @@ export default function ComparisonPanel({
             to access courses and events
           </p>
         </ReactTooltip> */}
-        <Modal
-          className="not-signed-in-modal"
-          show={signedInModal}
-          onHide={(): void => setSignedInModal(false)}
-          buttons={[
-            {
-              label: 'Got it!',
-              onClick: (): void => {
-                setSignedInModal(false);
-              },
-            },
-          ]}
-          preserveChildrenWhileHiding
-        >
-          <p style={{ textAlign: 'center' }}>
-            Users should sign in to use the Compare Schedules panel.
-          </p>
-        </Modal>
+        <LoginModal show={loginOpen} onHide={hideLogin} comparison />
       </div>
     </div>
   );

--- a/src/components/ComparisonPanel/index.tsx
+++ b/src/components/ComparisonPanel/index.tsx
@@ -58,7 +58,7 @@ export default function ComparisonPanel({
   return (
     <div className="comparison-panel">
       <div
-        className="drawer"
+        className={classes('drawer', expanded && 'opened')}
         onClick={(): void => {
           setExpanded(!expanded);
           setHover(false);
@@ -69,11 +69,11 @@ export default function ComparisonPanel({
         onMouseLeave={(): void => setHover(false)}
         id={tooltipId}
       >
-        <div className="drawer-line" />
+        <div className={classes('drawer-line', expanded && 'opened')} />
         <div className="icon">
           <div className={classes('arrow', expanded && 'right')} />
         </div>
-        <div className="drawer-line" />
+        <div className={classes('drawer-line', expanded && 'opened')} />
         <ReactTooltip
           key={tooltipY}
           anchorId={tooltipId}

--- a/src/components/ComparisonPanel/index.tsx
+++ b/src/components/ComparisonPanel/index.tsx
@@ -6,7 +6,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { CombinationContainer, ComparisonContainer } from '..';
 import { AccountContext } from '../../contexts/account';
 import { classes } from '../../utils/misc';
-import Modal from '../Modal';
 import InvitationModal from '../InvitationModal';
 import LoginModal from '../LoginModal';
 

--- a/src/components/ComparisonPanel/stylesheet.scss
+++ b/src/components/ComparisonPanel/stylesheet.scss
@@ -6,12 +6,17 @@
 
   .drawer {
     width: 13px;
-    border-width: 0px 1px 0px 1px;
-    border-color: $color-border;
+    border-width: 0px 0px 0px 1px;
+    border-color: rgba(255, 255, 255, 0.50);
     border-style: solid;
     display: flex;
     flex-direction: column;
     align-items: center;
+
+    &.opened {
+      border-color: $color-border;
+      border-width: 0px 1px 0px 1px;
+    }
 
     &:hover {
       background: $color-border;
@@ -21,8 +26,11 @@
       flex: 1;
       width: 5px;
       border-width: 0px 1px 0px 1px;
-      border-color: $color-border;
+      border-color: rgba(255, 255, 255, 0.50);
       border-style: solid;
+      &.opened {
+        border-color: $color-border;
+      }
     }
 
     .icon {
@@ -37,13 +45,14 @@
         width: 10px;
         right: -8px;
         border-width: 0px 2px 2px 0px;
-        border-color: $color-border;
+        border-color: rgba(255, 255, 255);
         border-style: solid;
         transform: rotate(135deg);
 
         &.right {
           left: -8px;
           transform: rotate(-45deg);
+          border-color: $color-border;
         }
       }
     }

--- a/src/components/ComparisonPanel/stylesheet.scss
+++ b/src/components/ComparisonPanel/stylesheet.scss
@@ -45,7 +45,7 @@
         width: 10px;
         right: -8px;
         border-width: 0px 2px 2px 0px;
-        border-color: rgba(255, 255, 255);
+        border-color: rgba(255, 255, 255, 1);
         border-style: solid;
         transform: rotate(135deg);
 

--- a/src/components/LoginModal/index.tsx
+++ b/src/components/LoginModal/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import firebaseui from 'firebaseui';
 import FirebaseAuth from 'react-firebaseui/FirebaseAuth';
 
+import { classes } from '../../utils/misc';
 import Modal from '../Modal';
 import { firebase, authProviders } from '../../data/firebase';
 
@@ -17,11 +18,15 @@ const uiConfig: firebaseui.auth.Config = {
   },
 };
 
+export type LoginModalContentProps = { comparison: boolean };
+
 /**
  * Inner content of the login modal.
  * This utilizes Firebase UI to handle the authentication UI components.
  */
-export function LoginModalContent(): React.ReactElement {
+export function LoginModalContent({
+  comparison,
+}: LoginModalContentProps): React.ReactElement {
   // Calculate the min height of the FirebaseUI element
   // so that it does not cause a large layout shift when initially loading.
   // The height is determined based on the number of auth providers,
@@ -34,11 +39,20 @@ export function LoginModalContent(): React.ReactElement {
 
   return (
     <div className="login-modal-content">
-      <h1>Sign in</h1>
-      <p className="login-modal-content__body">
-        Sign in using one of the below identity providers to start syncing your
-        schedules across devices.
-      </p>
+      {comparison ? (
+        <p className="compare-text">
+          You must <span className="underline">sign in</span> to use the Compare
+          Schedule Feature!
+        </p>
+      ) : (
+        <h1>Sign in</h1>
+      )}
+      <div className={classes(comparison && 'compare-subtext')}>
+        <p className="login-modal-content__body">
+          Sign in using one of the below identity providers to start syncing
+          your schedules across devices.
+        </p>
+      </div>
       <div style={{ minHeight }}>
         <FirebaseAuth
           className="login-modal-content__firebase-ui"
@@ -53,6 +67,7 @@ export function LoginModalContent(): React.ReactElement {
 export type LoginModalProps = {
   show: boolean;
   onHide: () => void;
+  comparison?: boolean;
 };
 
 /**
@@ -62,6 +77,7 @@ export type LoginModalProps = {
 export default function LoginModal({
   show,
   onHide,
+  comparison = false,
 }: LoginModalProps): React.ReactElement {
   // If the modal is open,
   // attach a listener for the authentication state
@@ -87,7 +103,7 @@ export default function LoginModal({
         { label: 'Cancel', onClick: (): void => onHide(), cancel: true },
       ]}
     >
-      <LoginModalContent />
+      <LoginModalContent comparison={comparison} />
     </Modal>
   );
 }

--- a/src/components/LoginModal/stylesheet.scss
+++ b/src/components/LoginModal/stylesheet.scss
@@ -62,4 +62,31 @@
     text-align: center;
     margin-bottom: 28px;
   }
+
+  .underline {
+    text-decoration: underline;
+    font-weight: 700;
+    color: #FFFFFF;
+  }
+
+  .compare-text {
+    text-align: center;
+    font-family: Roboto;
+    font-size: 25px;
+    font-style: normal;
+    font-weight: 600;
+    line-height: normal;
+    padding: 10px 1px 0px 1px;
+    color: #FFFFFF;
+  }
+
+  .compare-subtext {
+    width: 330px;
+    margin: 0 auto;
+    padding-bottom: 15px;
+    font-size: 15px;
+    font-weight: 400;
+    color: #FFFFFF;
+    
+  }
 }


### PR DESCRIPTION
### Summary

Resolves #293

Edit style of expand button for comparison panel and Trigger special LoginModal when user clicks 'share schedule' button or toggle compare button without logging in

### Checklist

- [x] Edit styling of the expand button for the comparison panel (refer to figma). Code for the button 
- [x] Trigger LoginModal (in components folder) when user clicks 'share schedule' button or toggle compare button without logging in. Look at HeaderActionBar for details on how to use the LoginModal component. Match the styling of the LoginModal to the styling of the figma and change text as well (previous LoginModal usage shouldn't change so maybe create props to determine text/styling). 


### How to Test
attempt sharing while not logged in