### PR TITLE
Preserve State for Compare Schedule

### DIFF
--- a/src/components/ComparisonPanel/index.tsx
+++ b/src/components/ComparisonPanel/index.tsx
@@ -19,18 +19,19 @@ export type ComparisonPanelProps = {
   ) => void;
   pinnedSchedules: string[];
   pinSelf: boolean;
+  compare: boolean;
 };
 
 export default function ComparisonPanel({
   handleCompareSchedules,
   pinnedSchedules,
   pinSelf,
+  compare,
 }: ComparisonPanelProps): React.ReactElement {
   const [expanded, setExpanded] = useState(true);
   const [hover, setHover] = useState(false);
   const [tooltipY, setTooltipY] = useState(0);
   const [signedInModal, setSignedInModal] = useState(false);
-  const [compare, setCompare] = useState(false);
   const [invitationOpen, setInvitationOpen] = useState(false);
   // const [hoverCompare, setHoverCompare] = useState(false);
   // const [tooltipYCompare, setTooltipYCompare] = useState(0);
@@ -48,7 +49,7 @@ export default function ComparisonPanel({
 
   const handleTogglePanel = useCallback(() => {
     if (type === 'signedIn') {
-      setCompare(!compare);
+      // setCompare(!compare);
       handleCompareSchedules(!compare, undefined, undefined);
     } else {
       setSignedInModal(true);

--- a/src/components/Scheduler/index.tsx
+++ b/src/components/Scheduler/index.tsx
@@ -10,6 +10,7 @@ import {
 } from '..';
 import { OverlayCrnsContext, OverlayCrnsContextValue } from '../../contexts';
 import { DESKTOP_BREAKPOINT } from '../../constants';
+import useLocalStorageState from 'use-local-storage-state';
 import useScreenWidth from '../../hooks/useScreenWidth';
 
 /**
@@ -30,9 +31,37 @@ export default function Scheduler(): React.ReactElement {
     [overlayCrns, setOverlayCrns]
   );
 
-  const [compare, setCompare] = useState(false);
-  const [pinnedSchedules, setPinnedSchedules] = useState<string[]>([]);
-  const [pinSelf, setPinSelf] = useState(true);
+  // const [{ currentTerm, versionStates }, setUIState] = useLocalStorageState(
+  //   UI_STATE_LOCAL_STORAGE_KEY,
+  //   {
+  //     defaultValue: defaultUIState,
+  //     storageSync: false,
+  //   }
+  // );
+
+  const [compare, setCompare] = useLocalStorageState<boolean>(
+    'compare-panel-state-compareValue',
+    {
+      defaultValue: false,
+      storageSync: false,
+    }
+  );
+  const [pinnedSchedules, setPinnedSchedules] = useLocalStorageState<string[]>(
+    'compare-panel-state-pinnedSchedules',
+    {
+      defaultValue: [],
+      storageSync: false,
+    }
+  );
+  const [pinSelf, setPinSelf] = useLocalStorageState<boolean>(
+    'compare-panel-state-pinSelfValue',
+    {
+      defaultValue: true,
+      storageSync: false,
+    }
+  );
+
+  console.log(compare);
 
   const handleCompareSchedules = useCallback(
     (
@@ -41,6 +70,7 @@ export default function Scheduler(): React.ReactElement {
       newPinSelf?: boolean
     ) => {
       if (newCompare !== undefined) {
+        console.log(newCompare);
         setCompare(newCompare);
       }
       if (newPinnedSchedules !== undefined) {
@@ -88,6 +118,7 @@ export default function Scheduler(): React.ReactElement {
               handleCompareSchedules={handleCompareSchedules}
               pinnedSchedules={pinnedSchedules}
               pinSelf={pinSelf}
+              compare={compare}
             />
           )}
         </div>

--- a/src/components/Scheduler/index.tsx
+++ b/src/components/Scheduler/index.tsx
@@ -31,14 +31,6 @@ export default function Scheduler(): React.ReactElement {
     [overlayCrns, setOverlayCrns]
   );
 
-  // const [{ currentTerm, versionStates }, setUIState] = useLocalStorageState(
-  //   UI_STATE_LOCAL_STORAGE_KEY,
-  //   {
-  //     defaultValue: defaultUIState,
-  //     storageSync: false,
-  //   }
-  // );
-
   const { compare, pinned, pinSelf, handleCompareSchedules } =
     useCompareStateFromStorage();
 

--- a/src/components/Scheduler/index.tsx
+++ b/src/components/Scheduler/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import { classes } from '../../utils/misc';
 import {

--- a/src/components/Scheduler/index.tsx
+++ b/src/components/Scheduler/index.tsx
@@ -10,7 +10,7 @@ import {
 } from '..';
 import { OverlayCrnsContext, OverlayCrnsContextValue } from '../../contexts';
 import { DESKTOP_BREAKPOINT } from '../../constants';
-import useLocalStorageState from 'use-local-storage-state';
+import useCompareStateFromStorage from '../../data/hooks/useCompareStateFromStorage';
 import useScreenWidth from '../../hooks/useScreenWidth';
 
 /**
@@ -39,49 +39,8 @@ export default function Scheduler(): React.ReactElement {
   //   }
   // );
 
-  const [compare, setCompare] = useLocalStorageState<boolean>(
-    'compare-panel-state-compareValue',
-    {
-      defaultValue: false,
-      storageSync: false,
-    }
-  );
-  const [pinnedSchedules, setPinnedSchedules] = useLocalStorageState<string[]>(
-    'compare-panel-state-pinnedSchedules',
-    {
-      defaultValue: [],
-      storageSync: false,
-    }
-  );
-  const [pinSelf, setPinSelf] = useLocalStorageState<boolean>(
-    'compare-panel-state-pinSelfValue',
-    {
-      defaultValue: true,
-      storageSync: false,
-    }
-  );
-
-  console.log(compare);
-
-  const handleCompareSchedules = useCallback(
-    (
-      newCompare?: boolean,
-      newPinnedSchedules?: string[],
-      newPinSelf?: boolean
-    ) => {
-      if (newCompare !== undefined) {
-        console.log(newCompare);
-        setCompare(newCompare);
-      }
-      if (newPinnedSchedules !== undefined) {
-        setPinnedSchedules(newPinnedSchedules);
-      }
-      if (newPinSelf !== undefined) {
-        setPinSelf(newPinSelf);
-      }
-    },
-    []
-  );
+  const { compare, pinned, pinSelf, handleCompareSchedules } =
+    useCompareStateFromStorage();
 
   return (
     <>
@@ -108,7 +67,7 @@ export default function Scheduler(): React.ReactElement {
                 className="calendar"
                 overlayCrns={overlayCrns}
                 compare={compare}
-                pinnedFriendSchedules={pinnedSchedules}
+                pinnedFriendSchedules={pinned}
                 pinSelf={!compare || pinSelf}
               />
             </div>
@@ -116,7 +75,7 @@ export default function Scheduler(): React.ReactElement {
           {(!mobile || tabIndex === 3) && (
             <ComparisonPanel
               handleCompareSchedules={handleCompareSchedules}
-              pinnedSchedules={pinnedSchedules}
+              pinnedSchedules={pinned}
               pinSelf={pinSelf}
               compare={compare}
             />

--- a/src/data/hooks/useCompareStateFromStorage.ts
+++ b/src/data/hooks/useCompareStateFromStorage.ts
@@ -1,8 +1,6 @@
 import { useCallback } from 'react';
 import useLocalStorageState from 'use-local-storage-state';
 
-export const UI_STATE_LOCAL_STORAGE_KEY = 'ui-state';
-
 type HookResult = {
   compare: boolean;
   pinned: string[];

--- a/src/data/hooks/useCompareStateFromStorage.ts
+++ b/src/data/hooks/useCompareStateFromStorage.ts
@@ -1,0 +1,75 @@
+import { useCallback } from 'react';
+import useLocalStorageState from 'use-local-storage-state';
+
+export const UI_STATE_LOCAL_STORAGE_KEY = 'ui-state';
+
+type HookResult = {
+  compare: boolean;
+  pinned: string[];
+  pinSelf: boolean;
+  handleCompareSchedules: (
+    newCompare: boolean | undefined,
+    newPinned: string[] | undefined,
+    newPinSelf: boolean | undefined
+  ) => void;
+};
+
+/**
+ * Gets the current UI state from local storage.
+ * Do not call this function in a non-root component;
+ * it should only be called once in a root component (i.e. <App>).
+ * Moreover, unlike the local storage version of the app data,
+ * this **does not** sync between tabs.
+ * This is deliberate, as it allows opening up multiple tabs
+ * with different schedules if desired,
+ * but still have the app resume to the last viewed schedule when opened again.
+ */
+export default function useCompareStateFromStorage(): HookResult {
+  const [compare, setCompare] = useLocalStorageState<boolean>(
+    'compare-panel-state-compareValue',
+    {
+      defaultValue: false,
+      storageSync: false,
+    }
+  );
+  const [pinned, setPinned] = useLocalStorageState<string[]>(
+    'compare-panel-state-pinnedSchedules',
+    {
+      defaultValue: [],
+      storageSync: false,
+    }
+  );
+  const [pinSelf, setPinSelf] = useLocalStorageState<boolean>(
+    'compare-panel-state-pinSelfValue',
+    {
+      defaultValue: true,
+      storageSync: false,
+    }
+  );
+
+  const handleCompareSchedules = useCallback(
+    (
+      newCompare?: boolean,
+      newPinnedSchedules?: string[],
+      newPinSelf?: boolean
+    ) => {
+      if (newCompare !== undefined) {
+        setCompare(newCompare);
+      }
+      if (newPinnedSchedules !== undefined) {
+        setPinned(newPinnedSchedules);
+      }
+      if (newPinSelf !== undefined) {
+        setPinSelf(newPinSelf);
+      }
+    },
+    []
+  );
+
+  return {
+    compare,
+    pinned,
+    pinSelf,
+    handleCompareSchedules,
+  };
+}

--- a/src/data/hooks/useCompareStateFromStorage.ts
+++ b/src/data/hooks/useCompareStateFromStorage.ts
@@ -63,7 +63,7 @@ export default function useCompareStateFromStorage(): HookResult {
         setPinSelf(newPinSelf);
       }
     },
-    []
+    [setCompare, setPinned, setPinSelf]
   );
 
   return {


### PR DESCRIPTION
Resolves #276 

Created a new hook to preserve the state of the compare schedule panel in local storage.

### How to Test

Toggle features of the compare schedule panel and refresh the page and notice they are unchanged.