### PR TITLE
Open compare schedule on accepting invitation

### DIFF
--- a/src/components/App/content.tsx
+++ b/src/components/App/content.tsx
@@ -8,7 +8,6 @@ import ErrorBoundary from '../ErrorBoundary';
 import HeaderDisplay from '../HeaderDisplay';
 import Map from '../Map';
 import Finals from '../Finals';
-import InvitationAcceptModal from '../InvitationAcceptModal/InvitationAcceptModal';
 import {
   AppNavigationContext,
   AppMobileNav,
@@ -64,7 +63,6 @@ function AppContentBase(): React.ReactElement {
         {currentTabIndex === 0 && <Scheduler />}
         {currentTabIndex === 1 && <Map />}
         {currentTabIndex === 2 && <Finals />}
-        <InvitationAcceptModal />
         {/* Fake calendar used to capture screenshots */}
         <div className="capture-container" ref={captureRef}>
           <Calendar className="fake-calendar" capture overlayCrns={[]} />

--- a/src/components/ComparisonPanel/index.tsx
+++ b/src/components/ComparisonPanel/index.tsx
@@ -60,7 +60,6 @@ export default function ComparisonPanel({
 
   const handleTogglePanel = useCallback(() => {
     if (type === 'signedIn') {
-      // setCompare(!compare);
       handleCompareSchedules(!compare, undefined, undefined);
     } else {
       setLoginOpen(true);

--- a/src/components/ComparisonPanel/index.tsx
+++ b/src/components/ComparisonPanel/index.tsx
@@ -8,6 +8,7 @@ import { AccountContext } from '../../contexts/account';
 import { classes } from '../../utils/misc';
 import InvitationModal from '../InvitationModal';
 import LoginModal from '../LoginModal';
+import InvitationAcceptModal from '../InvitationAcceptModal/InvitationAcceptModal';
 
 import './stylesheet.scss';
 
@@ -15,11 +16,13 @@ export type ComparisonPanelProps = {
   handleCompareSchedules: (
     compare?: boolean,
     pinnedSchedules?: string[],
-    pinSelf?: boolean
+    pinSelf?: boolean,
+    expanded?: boolean
   ) => void;
   pinnedSchedules: string[];
   pinSelf: boolean;
   compare: boolean;
+  expanded: boolean;
 };
 
 export default function ComparisonPanel({
@@ -27,8 +30,8 @@ export default function ComparisonPanel({
   pinnedSchedules,
   pinSelf,
   compare,
+  expanded,
 }: ComparisonPanelProps): React.ReactElement {
-  const [expanded, setExpanded] = useState(true);
   const [hover, setHover] = useState(false);
   const [tooltipY, setTooltipY] = useState(0);
   const [invitationOpen, setInvitationOpen] = useState(false);
@@ -66,10 +69,11 @@ export default function ComparisonPanel({
 
   return (
     <div className="comparison-panel">
+      <InvitationAcceptModal handleCompareSchedules={handleCompareSchedules} />
       <div
         className={classes('drawer', expanded && 'opened')}
         onClick={(): void => {
-          setExpanded(!expanded);
+          handleCompareSchedules(undefined, undefined, undefined, !expanded);
           setHover(false);
         }}
         onMouseEnter={(e: React.MouseEvent): void => {

--- a/src/components/InvitationAcceptModal/InvitationAcceptModal.tsx
+++ b/src/components/InvitationAcceptModal/InvitationAcceptModal.tsx
@@ -10,7 +10,18 @@ import InvitationModal from '../InvitationModal';
 
 import './stylesheet.scss';
 
-export default function InvitationAcceptModal(): React.ReactElement {
+export type InvitationAcceptModalProps = {
+  handleCompareSchedules: (
+    compare?: boolean,
+    pinnedSchedules?: string[],
+    pinSelf?: boolean,
+    expanded?: boolean
+  ) => void;
+};
+
+export default function InvitationAcceptModal({
+  handleCompareSchedules,
+}: InvitationAcceptModalProps): React.ReactElement {
   const [modalOpen, setModalOpen] = useState<boolean>(false);
   const [invitationModalOpen, setInvitationModalOpen] =
     useState<boolean>(false);
@@ -40,6 +51,7 @@ export default function InvitationAcceptModal(): React.ReactElement {
   const onHide = (): void => {
     setHasSeen(true);
     setModalOpen(!modalOpen);
+    handleCompareSchedules(true, undefined, undefined, true);
   };
 
   return (

--- a/src/components/InvitationAcceptModal/InvitationAcceptModal.tsx
+++ b/src/components/InvitationAcceptModal/InvitationAcceptModal.tsx
@@ -92,7 +92,7 @@ export default function InvitationAcceptModal({
                     type="submit"
                     className="share-button"
                     onClick={(): void => {
-                      setHasSeen(true);
+                      onHide();
                       setInvitationModalOpen(true);
                     }}
                   >

--- a/src/components/Scheduler/index.tsx
+++ b/src/components/Scheduler/index.tsx
@@ -31,7 +31,7 @@ export default function Scheduler(): React.ReactElement {
     [overlayCrns, setOverlayCrns]
   );
 
-  const { compare, pinned, pinSelf, setCompareState } =
+  const { compare, pinned, pinSelf, expanded, setCompareState } =
     useCompareStateFromStorage();
 
   return (
@@ -70,6 +70,7 @@ export default function Scheduler(): React.ReactElement {
               pinnedSchedules={pinned}
               pinSelf={pinSelf}
               compare={compare}
+              expanded={expanded}
             />
           )}
         </div>

--- a/src/data/hooks/useCompareStateFromStorage.ts
+++ b/src/data/hooks/useCompareStateFromStorage.ts
@@ -5,10 +5,12 @@ type HookResult = {
   compare: boolean;
   pinned: string[];
   pinSelf: boolean;
+  expanded: boolean;
   setCompareState: (
     newCompare: boolean | undefined,
     newPinned: string[] | undefined,
-    newPinSelf: boolean | undefined
+    newPinSelf: boolean | undefined,
+    newExpanded: boolean | undefined
   ) => void;
 };
 
@@ -44,12 +46,20 @@ export default function useCompareStateFromStorage(): HookResult {
       storageSync: false,
     }
   );
+  const [expanded, setExpanded] = useLocalStorageState<boolean>(
+    'compare-panel-state-expandedValue',
+    {
+      defaultValue: true,
+      storageSync: false,
+    }
+  );
 
   const setCompareState = useCallback(
     (
       newCompare?: boolean,
       newPinnedSchedules?: string[],
-      newPinSelf?: boolean
+      newPinSelf?: boolean,
+      newExpanded?: boolean
     ) => {
       if (newCompare !== undefined) {
         setCompare(newCompare);
@@ -60,14 +70,18 @@ export default function useCompareStateFromStorage(): HookResult {
       if (newPinSelf !== undefined) {
         setPinSelf(newPinSelf);
       }
+      if (newExpanded !== undefined) {
+        setExpanded(newExpanded);
+      }
     },
-    [setCompare, setPinned, setPinSelf]
+    [setCompare, setPinned, setPinSelf, setExpanded]
   );
 
   return {
     compare,
     pinned,
     pinSelf,
+    expanded,
     setCompareState,
   };
 }


### PR DESCRIPTION
### Summary

Resolves #302 

Now when a user accepts an invite, the compare panel is expanded and compare mode is enabled when the modal is closed.

### How to Test

Sending invites through the modal doesn't work, but you can use query parameters to send fake invites.