### PR TITLE
Improve getCourseDataFromCourseCritique Data Flow #301

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "axios": "^0.21.4",
     "cheerio": "^1.0.0-rc.3",
     "copy-to-clipboard": "^3.3.1",
+    "date-and-time": "^3.1.1",
     "dom-to-image": "^2.6.0",
     "exponential-backoff": "^3.1.0",
     "fast-safe-stringify": "^2.1.0",
@@ -39,6 +40,7 @@
     "s-ago": "^2.2.0",
     "tslib": "2.3.0",
     "use-local-storage-state": "^18.1.2",
+    "util": "^0.12.5",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@sentry/tracing": "^6.12.0",
     "@types/react-map-gl": "^6.1.3",
     "axios": "^0.21.4",
+    "brotli-wasm": "^2.0.1",
     "cheerio": "^1.0.0-rc.3",
     "copy-to-clipboard": "^3.3.1",
     "date-and-time": "^3.1.1",
@@ -40,7 +41,6 @@
     "s-ago": "^2.2.0",
     "tslib": "2.3.0",
     "use-local-storage-state": "^18.1.2",
-    "util": "^0.12.5",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/src/data/beans/Course.ts
+++ b/src/data/beans/Course.ts
@@ -311,14 +311,11 @@ export default class Course {
     if (firestoreCacheItem != null) {
       const age = getCacheItemAge(firestoreCacheItem);
       if (age < 60 * 60 * 24) {
-        console.log('Using firestore cache');
         const decompressedData = await decompressData(firestoreCacheItem.d);
         return this.decodeCourseCritiqueResponse(
           JSON.parse(decompressedData) as CourseDetailsAPIResponse
         );
       }
-    } else {
-      console.log('Not in firestore cache');
     }
 
     let responseData: CourseDetailsAPIResponse;

--- a/src/data/beans/Course.ts
+++ b/src/data/beans/Course.ts
@@ -1,5 +1,7 @@
 import axios from 'axios';
 import { decode } from 'html-entities';
+import date from 'date-and-time';
+import util from 'util';
 
 import { Oscar, Section } from '.';
 import {
@@ -16,6 +18,8 @@ import {
 } from '../../utils/misc';
 import { ErrorWithFields, softError } from '../../log';
 import { CLOUD_FUNCTION_BASE_URL } from '../../constants';
+import { cacheCollection, isAuthEnabled } from '../firebase';
+import { CacheItem } from '../types';
 
 // This is actually a transparent read-through cache
 // in front of the Course Critique API's course data endpoint,
@@ -268,6 +272,24 @@ export default class Course {
     return courseGpa;
   }
 
+  private async getCacheItemFromFirestore(
+    courseID: string
+  ): Promise<CacheItem | null> {
+    if (!isAuthEnabled) {
+      return null;
+    }
+    const document = await cacheCollection.doc(courseID).get();
+    if (document.exists) {
+      const data = document.data();
+
+      if (data != null) {
+        return data;
+      }
+    }
+
+    return null;
+  }
+
   /**
    * Fetches the course GPA without caching it
    * @see `fetchGpa` for the persistent-caching version
@@ -283,6 +305,16 @@ export default class Course {
     const id = `${this.subject} ${this.number.replace(/\D/g, '')}`;
     const encodedCourse = encodeURIComponent(id);
     const url = `${COURSE_CRITIQUE_API_URL}?courseID=${encodedCourse}`;
+
+    // Try to see if firestore cache has the data
+    const firestoreCacheItem = await this.getCacheItemFromFirestore(id);
+    if (firestoreCacheItem != null) {
+      const age = getCacheItemAge(firestoreCacheItem);
+      if (age < 60 * 60 * 24) {
+        console.log('Using firestore cache');
+        console.log('d', firestoreCacheItem.d);
+      }
+    }
 
     let responseData: CourseDetailsAPIResponse;
     try {
@@ -448,4 +480,11 @@ interface CourseDetailsAPIResponse {
     F: number | unknown;
     W: number | unknown;
   }>;
+}
+
+function getCacheItemAge(cacheItem: CacheItem): number {
+  const now = new Date();
+  const timestamp = new Date(cacheItem.t);
+  const age = Math.max(0, date.subtract(now, timestamp).toSeconds());
+  return Math.floor(age);
 }

--- a/src/data/firebase.ts
+++ b/src/data/firebase.ts
@@ -3,7 +3,7 @@ import 'firebase/auth';
 import 'firebase/firestore';
 
 import { ErrorWithFields, softError } from '../log';
-import { AnyScheduleData } from './types';
+import { AnyScheduleData, CacheItem } from './types';
 
 // This data is not secret; it is included in the application bundle.
 // Supply these environment variables when developing locally.
@@ -18,6 +18,7 @@ export const firebaseConfig = {
 };
 
 const SCHEDULE_COLLECTION = 'schedules';
+const CACHE_COLLECTION = 'course_critique_course_data_cache';
 
 /**
  * Whether Firebase authentication is enabled in this environment.
@@ -32,8 +33,10 @@ let db: firebase.firestore.Firestore =
   null as unknown as firebase.firestore.Firestore;
 type SchedulesCollection =
   firebase.firestore.CollectionReference<AnyScheduleData>;
+type CacheCollection = firebase.firestore.CollectionReference<CacheItem>;
 let schedulesCollection: SchedulesCollection =
   null as unknown as SchedulesCollection;
+let cacheCollection: CacheCollection = null as unknown as CacheCollection;
 /* eslint-enable import/no-mutable-exports */
 if (isAuthEnabled) {
   const app = firebase.initializeApp(firebaseConfig);
@@ -43,6 +46,8 @@ if (isAuthEnabled) {
   schedulesCollection = db.collection(
     SCHEDULE_COLLECTION
   ) as SchedulesCollection;
+
+  cacheCollection = db.collection(CACHE_COLLECTION) as CacheCollection;
 
   auth.setPersistence(firebase.auth.Auth.Persistence.LOCAL).catch((err) => {
     softError(
@@ -54,7 +59,7 @@ if (isAuthEnabled) {
   });
 }
 
-export { auth, db, schedulesCollection };
+export { auth, db, schedulesCollection, cacheCollection };
 export { firebase };
 
 // Configure the enabled auth providers that firebase UI displays as options

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -142,3 +142,18 @@ export interface Version3Schedule {
   colorMap: Record<string, string>;
   sortingOptionIndex: number;
 }
+
+export interface CacheItem {
+  // ISO 8601 date-time that the item was added
+  t: string;
+  // Schema version
+  // (old versions are ignored)
+  v: 1;
+  // Opaque Course Critique API response string,
+  // brotli-compressed before being stored
+  d: string;
+  // Opaque Course Critique API status code
+  s: number;
+  // The content-type of the response string
+  c: string;
+}


### PR DESCRIPTION
### Summary

Resolves #301

Improves data flow of getting course data from course critique by checking firestore cache from client side before invoking the cloud function invocation to get course data

### Checklist

- [ ] Branch from main
- [ ] Refer to the development firebase project (ask EM for access) for more information on how course_critique_course_data_cache is structured. Also read https://github.com/gt-scheduler/firebase-conf/blob/main/functions/src/course_critique_cache.ts to figure out how to decode information stored in this collection as well as what the fields signify.
- [ ] Edit the fetchGpa function in src/data/beans/Course.ts (this function is called in src/Components/Course/index.tsx to populate the UI) to now first check firestore for a valid cache entry (this code can be taken from the cloud function) after an invalid entry is found in localStorage and then proceed to make a cloud function call only when localStorage and firebase have an invalid entry. The code currently only checks localStorage.
- [ ] Do thorough testing to make sure this entire flow works as expected.


### How to Test
add courses to scheduler, put logs into Course.ts to see when calls are made to API and Database