### PR TITLE
Resolve GT-Scheduler .ics export puts all classes 1 hour early

### DIFF
--- a/src/utils/misc.tsx
+++ b/src/utils/misc.tsx
@@ -279,9 +279,6 @@ const getDateRange = (term: string): DateRange => {
   return { from, to };
 };
 
-// Difference between UTC and EST timezones in minutes
-export const EST_TIMEZONE_OFFSET = 240;
-
 /**
  * Exports the current schedule to a `.ics` file,
  * which allows for importing into a third-party calendar application.
@@ -305,7 +302,6 @@ export function exportCoursesToCalendar(
     return;
   }
 
-  const timezoneDiff = EST_TIMEZONE_OFFSET - new Date().getTimezoneOffset();
 
   const addEventsToCalendar = (
     period: Period,
@@ -322,11 +318,9 @@ export function exportCoursesToCalendar(
     ) {
       begin.setDate(begin.getDate() + 1);
     }
-    const startWithOffset = period.start + timezoneDiff;
-    const endWithOffset = period.end + timezoneDiff;
-    begin.setHours(startWithOffset / 60, startWithOffset % 60);
+    begin.setHours(period.start / 60, period.start % 60);
     const end = new Date(begin.getTime());
-    end.setHours(endWithOffset / 60, endWithOffset % 60);
+    end.setHours(period.end / 60, period.end % 60);
     const rrule = {
       freq: 'WEEKLY',
       until: to,


### PR DESCRIPTION
…e0161cbf1cd

### Summary

Resolves #334 and mentioned in #265

- Removed the static EST offset (bug exposed by Daylight Savings Time)
- Date objects should already be local timezone aware for calendar exports
- The vendor file for ICS does have a TODO for more explicit timezone handling.




### How to Test
Manual tests can be done by adjusting your machine local time and observing ICS file contents for DTSTART and DTEND.

> Expected behavior
> The correct date and times for each class are uploaded as events to your Google Calendar