### PR TITLE
Sorting by primary instructor and trimming array

### DIFF
--- a/src/data/beans/Section.ts
+++ b/src/data/beans/Section.ts
@@ -112,9 +112,16 @@ export default class Section {
         days: days === '&nbsp;' ? [] : days.split(''),
         where: decode(where),
         location: oscar.locations[locationIndex] ?? null,
-        instructors: instructors.map((instructor) =>
-          instructor.replace(/ \(P\)$/, '').trim()
-        ),
+        // place instructors with (P) first and trim all elements
+        instructors: instructors
+          .sort((a, b) => {
+            const aHasP = a.endsWith(' (P)');
+            const bHasP = b.endsWith(' (P)');
+            if (aHasP && !bHasP) return -1;
+            if (!aHasP && bHasP) return 1;
+            return 0;
+          })
+          .map((instructor) => instructor.replace(/ \(P\)$/, '').trim()),
         // We need some fallback here
         dateRange: oscar.dateRanges[dateRangeIndex] ?? {
           from: new Date(),


### PR DESCRIPTION
### Summary

Resolves #348 

<!-- What does this PR change and why? Discuss any breaking changes. -->
The primary instructor for a section is now always displayed even when they are not listed first in the instructors list. A by product of this fix is also that the primary instructor for each section is listed first in the calendar view. 

### Changes

The instructors array is now sorted to bring primary instructors (those with "(P)" after their name) to the front of the instructors array before it is passed into the UI components.

### Testing
Before (from prod): 
<img width="2201" height="1453" alt="image" src="https://github.com/user-attachments/assets/998115e3-0ea6-47ba-b63d-62432242171d" />

After (dev):
<img width="2212" height="1449" alt="image" src="https://github.com/user-attachments/assets/5a15d064-0253-4657-9888-df95de9a4d1e" />

A subset of classes/sections this problem is solved for (642 in total)
<img width="1964" height="1254" alt="image" src="https://github.com/user-attachments/assets/9e9be95b-8daa-45fa-b2d1-206bbfff2858" />
