### PR TITLE
Add support for local crawler

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -78,6 +78,12 @@ const BACKEND_BASE_URL = 'https://gt-scheduler.azurewebsites.net';
 const FIREBASE_PROJECT_ID = firebaseConfig.projectId || `gt-scheduler-web-dev`;
 const CLOUD_FUNCTION_BASE_URL = `https://us-east1-${FIREBASE_PROJECT_ID}.cloudfunctions.net`;
 
+// Replace URL with served url if you want to run with a local crawler
+// eg. http://localhost:8080
+const CUSTOM_CRAWLER_URL = undefined;
+const CRAWLER_BASE_URL =
+  CUSTOM_CRAWLER_URL || 'https://gt-scheduler.github.io/crawler-v2';
+
 const DONATE_LINK = 'https://opencollective.com/georgia-tech';
 
 const LARGE_DESKTOP_BREAKPOINT = 1200;
@@ -87,6 +93,7 @@ const LARGE_MOBILE_BREAKPOINT = 600;
 export {
   OPEN,
   CLOSE,
+  CRAWLER_BASE_URL,
   DAYS,
   PNG_SCALE_FACTOR,
   PALETTE,

--- a/src/data/hooks/useDownloadOscarData.ts
+++ b/src/data/hooks/useDownloadOscarData.ts
@@ -10,9 +10,10 @@ import {
   sleep,
 } from '../../utils/misc';
 import Cancellable from '../../utils/cancellable';
+import { CRAWLER_BASE_URL } from '../../constants';
 
 const constructTermDataUrl = (term: string): string =>
-  `https://gt-scheduler.github.io/crawler-v2/${term}.json`;
+  `${CRAWLER_BASE_URL}/${term}.json`;
 
 // Number of minutes between re-downloads of the oscar data
 const REFRESH_INTERVAL_MIN = 15;
@@ -42,7 +43,6 @@ export default function useDownloadOscarData(
   useEffect(() => {
     const loadOperation = new Cancellable();
     const url = constructTermDataUrl(term);
-
     async function loadAndRefresh(): Promise<void> {
       let isFirst = true;
       while (!loadOperation.isCancelled) {

--- a/src/data/hooks/useDownloadTerms.ts
+++ b/src/data/hooks/useDownloadTerms.ts
@@ -5,9 +5,9 @@ import { softError, ErrorWithFields } from '../../log';
 import { LoadingState, NonEmptyArray, Term } from '../../types';
 import { exponentialBackoff, isAxiosNetworkError } from '../../utils/misc';
 import Cancellable from '../../utils/cancellable';
+import { CRAWLER_BASE_URL } from '../../constants';
 
-const CRAWLER_INDEX_URL =
-  'https://gt-scheduler.github.io/crawler-v2/index.json';
+const CRAWLER_INDEX_URL = `${CRAWLER_BASE_URL}/index.json`;
 
 /**
  * Downloads the list of terms that the crawler has valid data for.


### PR DESCRIPTION
This in combination with a PR in the crawler repo will allow someone to run a local crawler instance with the local website instance to easily test changes. Please run the website on incognito because otherwise most times it will use the cached data :(.