### PR TITLE
Add submitMetrics hook

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -122,6 +122,11 @@
     ],
     // Disable false positives for render props
     "react/no-unstable-nested-components": ["error", { "allowAsProps": true }],
+
+    // Use ts version of no-shadow
+    "no-shadow": "off",
+    "@typescript-eslint/no-shadow": ["error"],
+
     // Allow code like `<>{children}</>` to convert React.ReactNode => React.ReactElement
     "react/jsx-no-useless-fragment": ["error", { "allowExpressions": true }]
   },

--- a/src/components/RouterComponent/index.tsx
+++ b/src/components/RouterComponent/index.tsx
@@ -3,8 +3,6 @@ import { Routes, Route, Navigate, HashRouter } from 'react-router-dom';
 
 import App from '../App';
 import InviteBackLink from '../InviteBackLink';
-// TEMPORARY PAGE
-import SubmitMetrics from '../../sandbox/SubmitMetrics';
 
 export default function RouterComponent(): React.ReactElement {
   return (
@@ -12,10 +10,6 @@ export default function RouterComponent(): React.ReactElement {
       <Routes>
         <Route path="/" element={<App />} />
         <Route path="/invite/:id" element={<InviteBackLink />} />
-
-        {/* THIS IS A TEMPORARY PAGE */}
-        <Route path="/sandbox/submitMetrics" element={<SubmitMetrics />} />
-
         <Route path="/pr-preview/:id">
           <Route path="" element={<App />} />
           <Route path="invite/:id" element={<InviteBackLink />} />

--- a/src/components/RouterComponent/index.tsx
+++ b/src/components/RouterComponent/index.tsx
@@ -3,6 +3,8 @@ import { Routes, Route, Navigate, HashRouter } from 'react-router-dom';
 
 import App from '../App';
 import InviteBackLink from '../InviteBackLink';
+// TEMPORARY PAGE
+import SubmitMetrics from '../../sandbox/SubmitMetrics';
 
 export default function RouterComponent(): React.ReactElement {
   return (
@@ -10,6 +12,10 @@ export default function RouterComponent(): React.ReactElement {
       <Routes>
         <Route path="/" element={<App />} />
         <Route path="/invite/:id" element={<InviteBackLink />} />
+
+        {/* THIS IS A TEMPORARY PAGE */}
+        <Route path="/sandbox/submitMetrics" element={<SubmitMetrics />} />
+
         <Route path="/pr-preview/:id">
           <Route path="" element={<App />} />
           <Route path="invite/:id" element={<InviteBackLink />} />

--- a/src/data/hooks/useSubmitMetrics.ts
+++ b/src/data/hooks/useSubmitMetrics.ts
@@ -1,0 +1,200 @@
+import axios, { AxiosPromise } from 'axios';
+import { useState } from 'react';
+import { Immutable } from 'immer';
+
+import { auth } from '../firebase';
+import { ErrorWithFields, softError } from '../../log';
+import { SubmitMetricsRequestData } from '../types';
+import { LoadingState } from '../../types';
+import { exponentialBackoff, isAxiosNetworkError } from '../../utils/misc';
+import Cancellable from '../../utils/cancellable';
+import { CLOUD_FUNCTION_BASE_URL } from '../../constants';
+import useDeepCompareEffect from '../../hooks/useDeepCompareEffect';
+
+type HookResult = {
+  success: boolean;
+};
+
+const url = `${CLOUD_FUNCTION_BASE_URL}/submitMetrics`;
+
+const MAX_RETRIES = 3;
+
+/**
+ * Submits metrics data to a Firebase cloud function for the given request data.
+ * Retries up to 3 times on errors
+ */
+export default function useSubmitMetrics({
+  requestData,
+}: {
+  requestData: Immutable<SubmitMetricsRequestData>;
+}): LoadingState<HookResult> {
+  const [state, setState] = useState<LoadingState<HookResult>>({
+    type: 'loading',
+  });
+
+  useDeepCompareEffect(() => {
+    const submitOperation = new Cancellable();
+
+    async function submit(): Promise<void> {
+      setState({
+        type: 'loading',
+      });
+
+      if (!validateMetricData(requestData)) {
+        const validationError = new ErrorWithFields({
+          message: 'an error occurred while validating metrics data',
+        });
+        softError(
+          new ErrorWithFields({
+            message: 'validation failed for metrics submission',
+            source: validationError,
+            fields: {
+              url,
+              metricName: requestData.metricName,
+              targets: requestData.targets,
+            },
+          })
+        );
+        setState({
+          type: 'error',
+          error: validationError,
+          stillLoading: false,
+          overview: validationError.message,
+        });
+        return;
+      }
+
+      let attemptNumber = 1;
+      while (!submitOperation.isCancelled && attemptNumber <= MAX_RETRIES) {
+        try {
+          const requestDataString = JSON.stringify({
+            IDToken: await auth.currentUser?.getIdToken(),
+            ...requestData,
+          });
+          /* eslint-disable max-len */
+          // This request should be made with content type is application/x-www-form-urlencoded.
+          // This is done to prevent a pre-flight CORS request made to the firebase function.
+          /* eslint-enable max-len */
+          const promise = axios({
+            method: 'POST',
+            url,
+            headers: {
+              'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            data: `data=${requestDataString}`,
+          }) as AxiosPromise<HookResult>;
+
+          const result = await submitOperation.perform(promise);
+          if (result.cancelled) {
+            return;
+          }
+
+          setState({
+            type: 'loaded',
+            result: { success: true },
+          });
+
+          return;
+        } catch (err) {
+          if (!isAxiosNetworkError(err)) {
+            softError(
+              new ErrorWithFields({
+                message: 'error submitting metrics',
+                source: err,
+                fields: {
+                  url,
+                  metricName: requestData.metricName,
+                  targets: requestData.targets,
+                },
+              })
+            );
+          }
+
+          setState({
+            type: 'error',
+            error:
+              err instanceof Error
+                ? err
+                : new ErrorWithFields({
+                    message: 'an error occurred while submitting metrics',
+                    source: err,
+                  }),
+            stillLoading: attemptNumber < MAX_RETRIES,
+            overview: String(err),
+          });
+
+          await exponentialBackoff(attemptNumber);
+          attemptNumber += 1;
+        }
+      }
+    }
+
+    submit().catch((err) => {
+      softError(
+        new ErrorWithFields({
+          message: 'error submitting metrics',
+          source: err,
+          fields: {
+            url,
+            metricName: requestData.metricName,
+            targets: requestData.targets,
+          },
+        })
+      );
+    });
+
+    // Cancel the submission when this cleans up
+    return (): void => {
+      submitOperation.cancel();
+    };
+  }, [requestData, setState]);
+
+  return state;
+}
+
+function validateMetricData(data: unknown): boolean {
+  if (typeof data !== 'object' || data === null) return false;
+  const d = data as SubmitMetricsRequestData;
+
+  if (!['difficulty', 'recommended'].includes(d.metricName)) return false;
+  if (!Array.isArray(d.targets)) return false;
+
+  for (const target of d.targets) {
+    if (typeof target !== 'object' || target === null) return false;
+    if (!['professor', 'course', 'section'].includes(target.type)) return false;
+    if (typeof target.reference !== 'string') return false;
+
+    switch (target.type) {
+      case 'course': {
+        // ABCD 1234
+        if (!/^[A-Z]+ \d{4}$/.test(target.reference)) return false;
+        break;
+      }
+
+      case 'professor': {
+        // FirstName LastName
+        const nameParts = target.reference.split(' ');
+        if (nameParts.length !== 2) return false;
+        break;
+      }
+
+      case 'section': {
+        // ABC01
+        if (!/^[A-Z]+\d+$/.test(target.reference)) return false;
+        break;
+      }
+
+      default: {
+        return false;
+      }
+    }
+  }
+
+  // YYYYMM
+  if (d.semester !== undefined) {
+    if (typeof d.semester !== 'number') return false;
+    if (!/^\d{6}$/.test(String(d.semester))) return false;
+  }
+
+  return true;
+}

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -220,3 +220,15 @@ export type FriendScheduleData = Record<
     >;
   }
 >;
+
+export interface MetricTarget {
+  type: 'professor' | 'course' | 'section';
+  reference: string;
+}
+
+export interface SubmitMetricsRequestData {
+  metricName: 'difficulty' | 'recommended';
+  targets: MetricTarget[];
+  values: number[];
+  semester?: number;
+}

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -224,13 +224,12 @@ export type FriendScheduleData = Record<
 // Metrics system types
 // ====================
 
-// eslint-disable-next-line @typescript-eslint/no-shadow
+// MetricNames are temporary
 export enum MetricName {
   DIFFICULTY = 'difficulty',
   RECOMMENDED = 'recommended',
 }
 
-// eslint-disable-next-line @typescript-eslint/no-shadow
 export enum TargetType {
   PROFESSOR = 'professor',
   COURSE = 'course',

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -221,14 +221,31 @@ export type FriendScheduleData = Record<
   }
 >;
 
+// Metrics system types
+// ====================
+
+// eslint-disable-next-line @typescript-eslint/no-shadow
+export enum MetricName {
+  DIFFICULTY = 'difficulty',
+  RECOMMENDED = 'recommended',
+}
+
+// eslint-disable-next-line @typescript-eslint/no-shadow
+export enum TargetType {
+  PROFESSOR = 'professor',
+  COURSE = 'course',
+  SECTION = 'section',
+}
+
 export interface MetricTarget {
-  type: 'professor' | 'course' | 'section';
+  type: TargetType;
   reference: string;
 }
 
-export interface SubmitMetricsRequestData {
-  metricName: 'difficulty' | 'recommended';
+export type SubmitMetricsRequestData = {
+  IDToken: string;
+  metricName: MetricName;
   targets: MetricTarget[];
   values: number[];
   semester?: number;
-}
+};

--- a/src/sandbox/SubmitMetrics/index.tsx
+++ b/src/sandbox/SubmitMetrics/index.tsx
@@ -1,0 +1,152 @@
+import React, { useState } from 'react';
+
+import { SubmitMetricsRequestData, MetricTarget } from '../../data/types';
+import useSubmitMetrics from '../../data/hooks/useSubmitMetrics';
+
+export default function SubmitMetrics(): React.ReactElement {
+  const [formData, setFormData] = useState<Partial<SubmitMetricsRequestData>>({
+    targets: [],
+    values: [],
+  });
+
+  const [metricName, setMetricName] = useState<
+    '' | 'difficulty' | 'recommended'
+  >('');
+  const [semester, setSemester] = useState<number | undefined>(undefined);
+  const [targetsJson, setTargetsJson] = useState('');
+  const [valuesJson, setValuesJson] = useState('');
+
+  const state = useSubmitMetrics({
+    requestData: formData as SubmitMetricsRequestData,
+  });
+
+  const handleSubmit = (e: React.FormEvent): void => {
+    e.preventDefault();
+
+    if (!metricName) return;
+
+    try {
+      const targets = JSON.parse(targetsJson) as MetricTarget[];
+      const values = JSON.parse(valuesJson) as number[];
+
+      setFormData({
+        metricName,
+        semester,
+        targets,
+        values,
+      });
+    } catch (err) {
+      // targets and values must be json
+    }
+  };
+
+  const handleMetricNameChange = (
+    e: React.ChangeEvent<HTMLSelectElement>
+  ): void => {
+    setMetricName(e.target.value as '' | 'difficulty' | 'recommended');
+  };
+
+  const handleSemesterChange = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ): void => {
+    setSemester(Number(e.target.value) || undefined);
+  };
+
+  const handleTargetsChange = (
+    e: React.ChangeEvent<HTMLTextAreaElement>
+  ): void => {
+    setTargetsJson(e.target.value);
+  };
+
+  const handleValuesChange = (
+    e: React.ChangeEvent<HTMLTextAreaElement>
+  ): void => {
+    setValuesJson(e.target.value);
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column' }}>
+      <h1>Submit Metrics</h1>
+      <form onSubmit={handleSubmit}>
+        <label htmlFor="metricName">
+          Metric Name:
+          <select
+            id="metricName"
+            value={metricName}
+            onChange={handleMetricNameChange}
+            style={{ color: 'black', backgroundColor: 'white' }}
+          >
+            <option value="">Select</option>
+            <option value="difficulty">difficulty</option>
+            <option value="recommended">recommended</option>
+          </select>
+        </label>
+        <br />
+        <label htmlFor="targets">
+          Targets:
+          <textarea
+            id="targets"
+            value={targetsJson}
+            onChange={handleTargetsChange}
+            rows={3}
+            cols={40}
+            placeholder='[{"type": "course", "reference": "CS 1331"}]'
+          />
+        </label>
+        <br />
+        <label htmlFor="values">
+          Values (JSON array of numbers):
+          <textarea
+            id="values"
+            value={valuesJson}
+            onChange={handleValuesChange}
+            rows={2}
+            cols={40}
+            placeholder="[4, 5, 3]"
+          />
+        </label>
+        <br />
+        <label htmlFor="semester">
+          Semester (YYYYMM, optional):
+          <input
+            style={{ color: 'black', backgroundColor: 'white' }}
+            id="semester"
+            type="number"
+            value={String(semester)}
+            onChange={handleSemesterChange}
+            placeholder="202409"
+            min="200000"
+            max="209912"
+            step="1"
+          />
+        </label>
+        <br />
+        <button type="submit" disabled={state.type === 'loading'}>
+          Submit
+        </button>
+      </form>
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <h3>State</h3>
+        {state.type === 'loading' && <p>Loading...</p>}
+        {state.type === 'loaded' && (
+          <p>Loaded: Success = {String(state.result?.success)}</p>
+        )}
+        {state.type === 'error' && (
+          <div>
+            <p>Error: {state.overview}</p>
+            {state.stillLoading && <p>Retrying...</p>}
+          </div>
+        )}
+        <h4>This is what will be sent:</h4>
+        <pre
+          style={{
+            backgroundColor: 'white',
+            color: 'black',
+          }}
+        >
+          {JSON.stringify(formData, null, 2)}
+        </pre>
+      </div>
+    </div>
+  );
+}

--- a/src/sandbox/SubmitMetrics/index.tsx
+++ b/src/sandbox/SubmitMetrics/index.tsx
@@ -1,6 +1,12 @@
+// DELETE LATER
+
 import React, { useState } from 'react';
 
-import { SubmitMetricsRequestData, MetricTarget } from '../../data/types';
+import {
+  SubmitMetricsRequestData,
+  MetricTarget,
+  MetricName,
+} from '../../data/types';
 import useSubmitMetrics from '../../data/hooks/useSubmitMetrics';
 
 export default function SubmitMetrics(): React.ReactElement {
@@ -9,9 +15,7 @@ export default function SubmitMetrics(): React.ReactElement {
     values: [],
   });
 
-  const [metricName, setMetricName] = useState<
-    '' | 'difficulty' | 'recommended'
-  >('');
+  const [metricName, setMetricName] = useState<MetricName | ''>('');
   const [semester, setSemester] = useState<number | undefined>(undefined);
   const [targetsJson, setTargetsJson] = useState('');
   const [valuesJson, setValuesJson] = useState('');
@@ -43,7 +47,7 @@ export default function SubmitMetrics(): React.ReactElement {
   const handleMetricNameChange = (
     e: React.ChangeEvent<HTMLSelectElement>
   ): void => {
-    setMetricName(e.target.value as '' | 'difficulty' | 'recommended');
+    setMetricName(e.target.value as MetricName | '');
   };
 
   const handleSemesterChange = (
@@ -77,8 +81,8 @@ export default function SubmitMetrics(): React.ReactElement {
             style={{ color: 'black', backgroundColor: 'white' }}
           >
             <option value="">Select</option>
-            <option value="difficulty">difficulty</option>
-            <option value="recommended">recommended</option>
+            <option value={MetricName.DIFFICULTY}>difficulty</option>
+            <option value={MetricName.RECOMMENDED}>recommended</option>
           </select>
         </label>
         <br />

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,78 @@
+import {
+  MetricName,
+  TargetType,
+  SubmitMetricsRequestData,
+} from '../data/types';
+
+// Course format: ABCD 1234
+export function validateCourse(reference: string): boolean {
+  return /^[A-Z]+ \d{4}$/.test(reference);
+}
+
+// Professor: alphabetical + spaces + hyphens
+export function validateProfessor(reference: string): boolean {
+  return /^[A-Za-z-]+(?:\s[A-Za-z-]+)*$/.test(reference);
+}
+
+// Section: ABC01 (letters + digits)
+export function validateSection(reference: string): boolean {
+  return /^[A-Z]+\d+$/.test(reference);
+}
+
+export function validateTarget(target: unknown): boolean {
+  if (typeof target !== 'object' || target === null) return false;
+
+  const t = target as { type: TargetType; reference: string };
+
+  if (!Object.values(TargetType).includes(t.type)) return false;
+  if (typeof t.reference !== 'string') return false;
+
+  switch (t.type) {
+    case TargetType.COURSE:
+      return validateCourse(t.reference);
+    case TargetType.PROFESSOR:
+      return validateProfessor(t.reference);
+    case TargetType.SECTION:
+      return validateSection(t.reference);
+    default:
+      return false;
+  }
+}
+
+export function validateSemester(value: unknown): boolean {
+  if (typeof value !== 'number') return false;
+
+  const str = String(value);
+  if (!/^\d{6}$/.test(str)) return false;
+
+  const year = Number(str.substring(0, 4));
+  const month = Number(str.substring(4, 6));
+
+  if (Number.isNaN(year) || year < 1970 || year > 2100) return false;
+  if (Number.isNaN(month)) return false;
+
+  // Allowed months: 01, 02, 03, 05, 06, 08, 09
+  const allowedMonths = new Set([1, 2, 3, 5, 6, 8, 9]);
+  return allowedMonths.has(month);
+}
+
+export function validateMetricData(data: unknown): boolean {
+  if (typeof data !== 'object' || data === null) return false;
+  const d = data as SubmitMetricsRequestData;
+
+  // Metric name
+  if (!Object.values(MetricName).includes(d.metricName)) return false;
+
+  // Targets
+  if (!Array.isArray(d.targets)) return false;
+  for (const target of d.targets) {
+    if (!validateTarget(target)) return false;
+  }
+
+  // Semester
+  if (d.semester !== undefined && !validateSemester(d.semester)) {
+    return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
### Summary

Resolves #355 

Adds submitMetrics hook, validation logic, and a sandbox page `#/sandbox/submitMetrics` to test the hook. submitMetrics calls the firebase cloud function submitMetrics and retries up to 3 times using exponential backoff. 

The sandbox page is located in `/src/sandbox/submitMetrics` and its route is set up in the router component. These should not go into production. 

### Checklist

- [x] Create a `useSubmitMetrics` hook in `src/data/hooks` that given a metrics type (that you will define similar to the previous ticket) will call the firebase function you just made. 
- [x] You will need to validate the data you send in the hook. Make utility functions for this.
- [x] Create a testing page `/sandbox/submitMetrics` with a sample form that lets you submit metrics using the hook. This should only be available on a dev environment not a prod environment. We will delete this later as it is just for testing, so do not worry about styling at all.
- [x] While fetching the data, if there is an error, retry a maximum of three times.

### How to Test

Testing can be done by going to `#/sandbox/submitMetrics`. The user must be authenticated and the firebase endpoint must have the submitMetrics function for the entire process to work. However, testing for errors (invalid data, unauthenticated user) can be done completely locally.   

<img width="767" height="802" alt="20250927_15h38m29s_grim" src="https://github.com/user-attachments/assets/e076d632-95b0-4e74-90b3-9fac1df6edbc" />