### PR TITLE
Close Mobile Side Panel on Click

### DIFF
--- a/src/components/App/navigation.tsx
+++ b/src/components/App/navigation.tsx
@@ -158,7 +158,10 @@ export function AppMobileNavDisplay({
       <NavMenu
         items={NAV_TABS}
         currentItem={currentTabIndex}
-        onChangeItem={setTabIndex}
+        onChangeItem={(next): void => {
+          setTabIndex(next);
+          closeDrawer();
+        }}
       />
     </NavDrawer>
   );


### PR DESCRIPTION
## Summary

Resolves #368 

This PR fixes a long-standing UX issue where the mobile navigation drawer remained open after selecting a tab. The expected behavior is that tapping a navigation item both (a) switches the active tab and (b) closes the drawer to reveal content. After this change, the drawer now closes immediately on selection.

Despite early guidance that this would be a “one-line fix,” the actual implementation required a modest four-line update to correctly wire the close action alongside the tab change. The end result is simple and predictable behavior with minimal code churn.



## Background
**Previous behavior:**  
- On mobile, opening the drawer and tapping a tab changed the active tab but left the drawer visible.
- Users had to manually dismiss the drawer to view content, adding an extra step.

**Desired behavior:**  
- Selecting a tab should immediately close the drawer so the newly selected view is visible.



## Implementation
- Added the drawer close action to the same click path that handles tab changes.
- Kept the change localized to the navigation event handler used by the mobile drawer flow.
- No layout, styling, or rendering changes were required.
- Total changes: **~4 lines** (handler composition + minor wiring).

*(Yes, the “1-line fix” characterization turned out to be optimistic.)*



## Behavior Changes
- **Mobile:** Selecting any navigation item now closes the drawer immediately after switching the tab.
- **Desktop:** Unchanged. The drawer is not used; tab switching works as before.
- **No regressions** to keyboard navigation or pointer interactions were observed.



## Rationale
- Reduces friction: one tap performs the full navigation action.
- Aligns with common mobile drawer patterns.
- Keeps logic in one place, which is easier to maintain and reason about.



## QA / Verification Steps
1. On a mobile-sized viewport, open the drawer.
2. Tap each tab in turn:
   - The active tab updates.
   - The drawer closes immediately.
3. Reopen the drawer and select the currently active tab:
   - No errors; drawer still closes.
4. Switch to a desktop-sized viewport:
   - Drawer controls are hidden.
   - Tab switching continues to work normally.