### PR TITLE
calendar size and CLOSE/OPEN refactor

### DIFF
--- a/src/components/Calendar/index.tsx
+++ b/src/components/Calendar/index.tsx
@@ -354,7 +354,7 @@ export default function Calendar({
     >
       {!preview && (
         <div className="times" ref={timesRef}>
-          {new Array((CLOSE - OPEN) / 60).fill(0).map((_, i) => {
+          {new Array((CLOSE + 1 - OPEN) / 60).fill(0).map((_, i) => {
             const time = OPEN + i * 60;
             return (
               <div className="time" key={time}>

--- a/src/components/EventAdd/index.tsx
+++ b/src/components/EventAdd/index.tsx
@@ -11,7 +11,7 @@ import { Immutable, castDraft } from 'immer';
 
 import Button from '../Button';
 import { classes, getRandomColor, timeToString } from '../../utils/misc';
-import { DAYS } from '../../constants';
+import { CLOSE, DAYS, OPEN } from '../../constants';
 import { ScheduleContext } from '../../contexts';
 import { Event as EventData } from '../../types';
 
@@ -76,8 +76,8 @@ export default function EventAdd({
       const parsedEnd = parseTime(end);
       if (parsedEnd !== -1 && parsedEnd <= parsedStart) {
         setError('Start time must be before end time.');
-      } else if (parsedStart < 480 || parsedEnd > 1320) {
-        setError('Event must be between 08:00 AM and 10:00 PM.');
+      } else if (parsedStart < OPEN || parsedEnd > CLOSE) {
+        setError('Event must be between 06:00 AM and 11:59 PM.');
       }
     },
     [end, parseTime]
@@ -94,8 +94,8 @@ export default function EventAdd({
       const parsedEnd = parseTime(newEnd);
       if (parsedStart !== -1 && parsedEnd <= parsedStart) {
         setError('Start time must be before end time.');
-      } else if (parsedStart < 480 || parsedEnd > 1320) {
-        setError('Event must be between 08:00 AM and 10:00 PM.');
+      } else if (parsedStart < OPEN || parsedEnd > CLOSE) {
+        setError('Event must be between 06:00 AM and 11:59 PM.');
       }
     },
     [start, parseTime]

--- a/src/components/EventBlocks/index.tsx
+++ b/src/components/EventBlocks/index.tsx
@@ -181,7 +181,7 @@ export default function EventBlocks({
             ref.current.offsetHeight / 2
         ) /
           timesRef.current.getBoundingClientRect().height) *
-          (CLOSE - OPEN) +
+          (CLOSE + 1 - OPEN) +
           OPEN) /
           5
       ) * 5;

--- a/src/components/EventDrag/index.tsx
+++ b/src/components/EventDrag/index.tsx
@@ -246,7 +246,7 @@ export default function EventDrag({
       pressRef.current = null;
       setDraftEvent(null);
 
-      // Only create event if draag actually covered at least 15 minutes
+      // Only create event if daag actually covered at least 15 minutes
       if (d && d.end - d.start >= MIN_EVENT_DURATION) {
         const eventId = new Date().getTime().toString();
 

--- a/src/components/EventDrag/index.tsx
+++ b/src/components/EventDrag/index.tsx
@@ -246,7 +246,7 @@ export default function EventDrag({
       pressRef.current = null;
       setDraftEvent(null);
 
-      // Only create event if daag actually covered at least 15 minutes
+      // Only create event if drag actually covered at least 15 minutes
       if (d && d.end - d.start >= MIN_EVENT_DURATION) {
         const eventId = new Date().getTime().toString();
 

--- a/src/components/EventDrag/index.tsx
+++ b/src/components/EventDrag/index.tsx
@@ -69,7 +69,10 @@ export default function EventDrag({
   } | null>(null);
 
   const snapTo = useCallback(
-    (m: number): number => Math.round(m / snap) * snap,
+    (m: number): number => {
+      const snapped = Math.round(m / snap) * snap;
+      return Math.min(snapped, CLOSE);
+    },
     [snap]
   );
 
@@ -141,6 +144,7 @@ export default function EventDrag({
     [daysRef, timesRef, snapTo]
   );
 
+  const rafIdRef = useRef<number | null>(null);
   // Resize the draftEvent as the pointer
   // moves, respecting bounds and min duration
   const handlePointerDown = useCallback(
@@ -206,7 +210,10 @@ export default function EventDrag({
 
       const next: DraftEvent = { day: pressDay, start, end };
       draftRef.current = next;
-      window.requestAnimationFrame(() => setDraftEvent(next));
+      if (rafIdRef.current) cancelAnimationFrame(rafIdRef.current);
+      rafIdRef.current = requestAnimationFrame(() => {
+        setDraftEvent(next);
+      });
 
       e.preventDefault();
     },
@@ -231,7 +238,15 @@ export default function EventDrag({
       pressRef.current = null;
       setDraftEvent(null);
 
-      // Only create event if drag actually covered at least 15 minutes
+      if (rafIdRef.current) {
+        cancelAnimationFrame(rafIdRef.current);
+        rafIdRef.current = null;
+      }
+      draftRef.current = null;
+      pressRef.current = null;
+      setDraftEvent(null);
+
+      // Only create event if draag actually covered at least 15 minutes
       if (d && d.end - d.start >= MIN_EVENT_DURATION) {
         const eventId = new Date().getTime().toString();
 

--- a/src/components/FinalBlocks/index.tsx
+++ b/src/components/FinalBlocks/index.tsx
@@ -57,9 +57,9 @@ export default function FinalBlocks({
             className={classes('meeting', contentClassName, 'default', day)}
             key={[i, day].join('-')}
             style={{
-              top: `${((finalTime.start - OPEN) / (CLOSE - OPEN)) * 100}%`,
+              top: `${((finalTime.start - OPEN) / (CLOSE + 1 - OPEN)) * 100}%`,
               height: `${
-                ((finalTime.end - finalTime.start) / (CLOSE - OPEN)) * 100
+                ((finalTime.end - finalTime.start) / (CLOSE + 1 - OPEN)) * 100
               }%`,
               width: `${width / sizeInfoPeriodDay.rowSize}%`,
               left: `${

--- a/src/components/Finals/index.tsx
+++ b/src/components/Finals/index.tsx
@@ -139,7 +139,7 @@ export default function Finals(): React.ReactElement {
   return (
     <div className="FinalsContainer">
       <div className="times">
-        {new Array((CLOSE - OPEN) / 60).fill(0).map((_, i) => {
+        {new Array((CLOSE + 1 - OPEN) / 60).fill(0).map((_, i) => {
           const time = OPEN + i * 60;
           return (
             <div className="time" key={time}>

--- a/src/components/Finals/index.tsx
+++ b/src/components/Finals/index.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 
-import { CLOSE, OPEN } from '../../constants';
+import { FINALS_CLOSE, FINALS_OPEN } from '../../constants';
 import { timeToShortString } from '../../utils/misc';
 import { ScheduleContext } from '../../contexts';
 import { FinalBlocks } from '..';
@@ -139,8 +139,8 @@ export default function Finals(): React.ReactElement {
   return (
     <div className="FinalsContainer">
       <div className="times">
-        {new Array((CLOSE + 1 - OPEN) / 60).fill(0).map((_, i) => {
-          const time = OPEN + i * 60;
+        {new Array((FINALS_CLOSE - FINALS_OPEN) / 60).fill(0).map((_, i) => {
+          const time = FINALS_OPEN + i * 60;
           return (
             <div className="time" key={time}>
               <span className="label">{timeToShortString(time)}</span>

--- a/src/components/TimeBlocks/index.tsx
+++ b/src/components/TimeBlocks/index.tsx
@@ -211,13 +211,13 @@ function MeetingDayBlock({
         )}
         style={{
           top: `${
-            (((tempStart ?? period.start) - OPEN) / (CLOSE - OPEN)) * 100
+            (((tempStart ?? period.start) - OPEN) / (CLOSE + 1 - OPEN)) * 100
           }%`,
           left: `${
             DAYS.indexOf(day) * 20 + sizeInfo.rowIndex * (20 / sizeInfo.rowSize)
           }%`,
           height: `${
-            (Math.max(15, period.end - period.start) / (CLOSE - OPEN)) * 100
+            (Math.max(15, period.end - period.start) / (CLOSE + 1 - OPEN)) * 100
           }%`,
           width: `${20 / sizeInfo.rowSize}%`,
           ...({

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,8 @@ import { firebaseConfig } from './data/firebase';
 
 const OPEN = 6 * 60;
 const CLOSE = 24 * 60 - 1; // 11:59 PM
+const FINALS_OPEN = 8 * 60;
+const FINALS_CLOSE = 22 * 60;
 const DAYS = ['M', 'T', 'W', 'R', 'F'];
 
 const PNG_SCALE_FACTOR = 2;
@@ -97,6 +99,8 @@ const LARGE_MOBILE_BREAKPOINT = 600;
 export {
   OPEN,
   CLOSE,
+  FINALS_OPEN,
+  FINALS_CLOSE,
   CRAWLER_BASE_URL,
   COURSE_TABS,
   COURSES,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,7 @@
 import { firebaseConfig } from './data/firebase';
 
-const OPEN = 8 * 60;
-const CLOSE = 22 * 60;
+const OPEN = 6 * 60;
+const CLOSE = 24 * 60 - 1; // 11:59 PM
 const DAYS = ['M', 'T', 'W', 'R', 'F'];
 
 const PNG_SCALE_FACTOR = 2;

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -1,4 +1,4 @@
-$calendar-height: 920px;
+$calendar-height: 1180px;
 $calendar-width: 720px;
 $time-width: 48px;
 $day-height: 40px;


### PR DESCRIPTION
### Summary

Resolves #366 

extend the scheduler’s active hours from 8 AM–10 PM to 6 AM–11:59 PM. OPEN and CLOSE constants in src/constants.ts were updated to 60*6 and 60*24 - 1, and the calendar height was increased from 920px to 1180px to fit the new timeframe and make sure event blocks remained the same height.

Additionally fixed bug where a ghost event drag (transparent block) would remain on the screen after a quick drag-and-release. The drag logic now cancels pending animation frames so the draft always disappears immediately.


### How to Test

NEW: add a 50 minute class and make sure prof name doesn't overflow (ensure event block height isnt smushed)
adding recurring events (manually or dragging to create)
dragging to move recurring events
mobile
schedule export
.ics export