### PR TITLE
add mapbox token to ci workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,7 @@ jobs:
         run: yarn build
         env:
           CI: 'true'
+          REACT_APP_MAPBOX_TOKEN: ${{ secrets.REACT_APP_MAPBOX_TOKEN }}
           PUBLIC_URL: ${{ env.npm_package_homepage }}/pr-preview/pr-${{ github.event.number }}/
           REACT_APP_PREVIEW: 'true'
           REACT_APP_FIREBASE_API_KEY: ${{ secrets.REACT_APP_FIREBASE_API_KEY_DEV }}


### PR DESCRIPTION
The Map doesn't render on deploy previews because the ci.yaml workflow does not include the mapbox token. 