### PR TITLE
Change 'Delivery Mode' to 'Class Format'

### DIFF
--- a/src/components/CourseAdd/index.tsx
+++ b/src/components/CourseAdd/index.tsx
@@ -220,7 +220,7 @@ export default function CourseAdd({
           </div>
         </div>
         {[
-          ['Delivery Mode', 'deliveryMode', DELIVERY_MODES] as const,
+          ['Class Format', 'deliveryMode', DELIVERY_MODES] as const,
           ['Campus', 'campus', CAMPUSES] as const,
         ].map(([name, property, labels]) => (
           <CourseFilter


### PR DESCRIPTION
### Summary

This PR changes the phrase "delivery mode" to be "class format" as requested by exec in the GT-Scheduler Changes for this semester. It hasn't been done yet and didn't need a ticket to be completed since it literally changes two words.