### PR TITLE
Overflowing Location Bug

### DIFF
--- a/src/components/TimeBlocks/index.tsx
+++ b/src/components/TimeBlocks/index.tsx
@@ -272,11 +272,19 @@ function MeetingDayBlock({
                 ))}
             </div>
 
-            {contentBody.map((content, i) => (
-              <span className={content.className} key={`content-body-${i}`}>
-                {content.content}
-              </span>
-            ))}
+            {contentBody.map((content, i) => {
+              const name = String(content.className).toLowerCase();
+              const durationMinutes = period.end - period.start;
+              const shouldHideLocation =
+                (name === 'location' || name === 'where') &&
+                durationMinutes < 49;
+              if (shouldHideLocation) return null;
+              return (
+                <span className={content.className} key={`content-body-${i}`}>
+                  {content.content}
+                </span>
+              );
+            })}
           </div>
         )}
       </BlockElement>

--- a/src/components/TimeBlocks/index.tsx
+++ b/src/components/TimeBlocks/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useId } from 'react';
+import React, { useContext, useId, useEffect, useState } from 'react';
 import { Tooltip as ReactTooltip } from 'react-tooltip';
 import { useRootClose } from 'react-overlays';
 
@@ -198,7 +198,6 @@ function MeetingDayBlock({
   const isDraft = color === undefined;
   const [isHovered, setIsHovered] = React.useState(false);
   const BlockElement = canBeTabFocused ? 'button' : 'div';
-
   return (
     <div ref={outerRef}>
       <BlockElement
@@ -274,11 +273,13 @@ function MeetingDayBlock({
 
             {contentBody.map((content, i) => {
               const name = String(content.className).toLowerCase();
-              const durationMinutes = period.end - period.start;
-              const shouldHideLocation =
-                (name === 'location' || name === 'where') &&
-                durationMinutes < 49;
-              if (shouldHideLocation) return null;
+              const isLocation = name === 'location' || name === 'where';
+              const isMobile =
+                typeof window !== 'undefined' &&
+                window.matchMedia('(max-width: 768px)').matches;
+              if (isLocation && period.end - period.start <= 30) return null;
+              if (isMobile && isLocation && period.end - period.start <= 49)
+                return null;
               return (
                 <span className={content.className} key={`content-body-${i}`}>
                   {content.content}

--- a/src/components/TimeBlocks/index.tsx
+++ b/src/components/TimeBlocks/index.tsx
@@ -271,21 +271,11 @@ function MeetingDayBlock({
                 ))}
             </div>
 
-            {contentBody.map((content, i) => {
-              const name = String(content.className).toLowerCase();
-              const isLocation = name === 'location' || name === 'where';
-              const isMobile =
-                typeof window !== 'undefined' &&
-                window.matchMedia('(max-width: 768px)').matches;
-              if (isLocation && period.end - period.start <= 30) return null;
-              if (isMobile && isLocation && period.end - period.start <= 49)
-                return null;
-              return (
-                <span className={content.className} key={`content-body-${i}`}>
-                  {content.content}
-                </span>
-              );
-            })}
+            {contentBody.map((content, i) => (
+              <span className={content.className} key={`content-body-${i}`}>
+                {content.content}
+              </span>
+            ))}
           </div>
         )}
       </BlockElement>

--- a/src/components/TimeBlocks/index.tsx
+++ b/src/components/TimeBlocks/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useId, useEffect, useState } from 'react';
+import React, { useContext, useId } from 'react';
 import { Tooltip as ReactTooltip } from 'react-tooltip';
 import { useRootClose } from 'react-overlays';
 

--- a/src/components/TimeBlocks/stylesheet.scss
+++ b/src/components/TimeBlocks/stylesheet.scss
@@ -171,6 +171,8 @@
 .meeting {
   overflow: hidden;
   clip-path: inset(0);
+  container-type: size;
+  container-name: meeting-block;
 }
 
 .meeting-wrapper {
@@ -195,7 +197,15 @@
 
 .mobile .meeting .meeting-wrapper {
   .location,
-  .where {
+  .where,
+  .period {
     white-space: nowrap !important;
+  }
+}
+
+@container meeting-block (max-height: 50px) {
+  .meeting-wrapper .location,
+  .meeting-wrapper .where {
+    display: none;
   }
 }

--- a/src/components/TimeBlocks/stylesheet.scss
+++ b/src/components/TimeBlocks/stylesheet.scss
@@ -168,3 +168,36 @@
     display: none;
   }
 }
+// DRAFT
+/* Prevent custom events (and any meeting) text from overflowing vertically or horizontally */
+.meeting {
+  overflow: hidden; /* ← this is key */
+  clip-path: inset(0); /* prevents visual bleeding in some browsers */
+}
+
+/* Prevent long text (like location) from spilling outside the meeting wrapper */
+.meeting-wrapper {
+  overflow: hidden;
+  max-height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
+  span {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    line-height: 1.1;
+    max-width: 100%;
+  }
+}
+
+/* Specific tightening for long custom event locations */
+.meeting-wrapper .where {
+  flex-shrink: 1;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+

--- a/src/components/TimeBlocks/stylesheet.scss
+++ b/src/components/TimeBlocks/stylesheet.scss
@@ -168,14 +168,11 @@
     display: none;
   }
 }
-// DRAFT
-/* Prevent custom events (and any meeting) text from overflowing vertically or horizontally */
 .meeting {
-  overflow: hidden; /* ← this is key */
-  clip-path: inset(0); /* prevents visual bleeding in some browsers */
+  overflow: hidden;
+  clip-path: inset(0);
 }
 
-/* Prevent long text (like location) from spilling outside the meeting wrapper */
 .meeting-wrapper {
   overflow: hidden;
   max-height: 100%;
@@ -190,14 +187,15 @@
     line-height: 1.1;
     max-width: 100%;
   }
+
+  .where {
+    flex-shrink: 1;
+  }
 }
 
-/* Specific tightening for long custom event locations */
-.meeting-wrapper .where {
-  flex-shrink: 1;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  max-width: 100%;
+.mobile .meeting .meeting-wrapper {
+  .location,
+  .where {
+    white-space: nowrap !important;
+  }
 }
-


### PR DESCRIPTION
### Summary

Resolves #383

Fixes overflow state for recurring events that are too small. excluded location on desktop and mobile

### How to Test
Copy Uma's exact location here:
<img width="299" height="207" alt="image" src="https://github.com/user-attachments/assets/83008c6f-ce84-4f14-8e23-d1af4a47a13e" />


make sure it doesn't overflow

play around with other times in desktop and mobile to make sure it doesn't overflow.