### PR TITLE
Fix out of order days

### DIFF
--- a/src/components/DaySelection/index.tsx
+++ b/src/components/DaySelection/index.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import { faAngleDown, faAngleUp } from '@fortawesome/free-solid-svg-icons';
 
 import { ActionRow } from '..';
-import { classes, getContentClassName } from '../../utils/misc';
+import { classes, getContentClassName, daysToString } from '../../utils/misc';
 import { Period, Event } from '../../types';
 import { ThemeContext } from '../../contexts';
 
@@ -158,7 +158,7 @@ export default function DaySelection({
                             </span>
                           )}
                         <span className="course-row">
-                          {course.daysOfWeek} {timeLabel}
+                          {daysToString(course.daysOfWeek)} {timeLabel}
                         </span>
                       </div>
                     );


### PR DESCRIPTION
### Summary

Resolves #404 

Uses `daysToString` util on the `course.daysOfWeek` to correctly order days in the DaySelection component. 
