### PR TITLE
Import courses by link

### DIFF
--- a/src/components/CourseAdd/index.tsx
+++ b/src/components/CourseAdd/index.tsx
@@ -11,7 +11,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
 
 import { Course, CourseFilter } from '..';
-import { classes, getRandomColor } from '../../utils/misc';
+import { classes, getRandomColor, normalizeCourseName } from '../../utils/misc';
 import { ASYNC_DELIVERY_MODE, CAMPUSES, DELIVERY_MODES } from '../../constants';
 import { ScheduleContext } from '../../contexts';
 import { Course as CourseBean, Section } from '../../data/beans';
@@ -86,17 +86,9 @@ export default function CourseAdd({
 
   const handleChangeKeyword = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
-      let input = e.target.value.trim();
-      const results = /^([A-Z]+)(\d.*)$/i.exec(input);
-      if (results != null) {
-        const [, subject, number] = results as unknown as [
-          string,
-          string,
-          string
-        ];
-        input = `${subject} ${number}`;
-      }
-      setKeyword(input);
+      const input = e.target.value.trim();
+      const normalizedName = normalizeCourseName(input);
+      setKeyword(normalizedName);
     },
     []
   );

--- a/src/components/CourseContainer/index.tsx
+++ b/src/components/CourseContainer/index.tsx
@@ -1,7 +1,14 @@
 import React, { useContext } from 'react';
 import ago from 's-ago';
 
-import { Button, Course, CourseAdd, Event, EventAdd } from '..';
+import {
+  Button,
+  Course,
+  CourseAdd,
+  Event,
+  EventAdd,
+  ImportCoursesModal,
+} from '..';
 import { ScheduleContext } from '../../contexts';
 import CourseNavMenu from '../CourseNavMenu';
 import { COURSE_TABS, COURSES } from '../../constants';
@@ -17,6 +24,7 @@ export default function CourseContainer(): React.ReactElement {
 
   return (
     <div className="CourseContainer">
+      <ImportCoursesModal />
       <CourseNavMenu
         items={COURSE_TABS}
         currentItem={courseContainerTab}

--- a/src/components/ImportCoursesModal/index.tsx
+++ b/src/components/ImportCoursesModal/index.tsx
@@ -72,7 +72,7 @@ export default function ImportCoursesModal(): React.ReactElement {
         <div className="courses-list">
           {courses
             .split(',')
-            .map((course) => normalizeCourseName(course.trim().toUpperCase()))
+            .map((course) => normalizeCourseName(course.trim()))
             .filter((course) => course.length > 0)
             .map((course, index) => (
               <div key={index}>{course}</div>

--- a/src/components/ImportCoursesModal/index.tsx
+++ b/src/components/ImportCoursesModal/index.tsx
@@ -1,0 +1,84 @@
+import { faXmark } from '@fortawesome/free-solid-svg-icons';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import Button from '../Button';
+import Modal from '../Modal';
+import useImportCourses from '../../hooks/useImportCourses';
+import { normalizeCourseName } from '../../utils/misc';
+
+import './stylesheet.scss';
+
+export default function ImportCoursesModal(): React.ReactElement {
+  const [modalOpen, setModalOpen] = useState<boolean>(false);
+  const [courses, setCourses] = useState<string>('');
+
+  const [searchParams] = useSearchParams();
+
+  const navigate = useNavigate();
+
+  const importCourses = useImportCourses();
+
+  useEffect(() => {
+    if (!searchParams.get('courses')) {
+      setModalOpen(false);
+      return;
+    }
+
+    const coursesParams = searchParams.get('courses');
+    setCourses(coursesParams ?? '');
+    setModalOpen(true);
+  }, [searchParams]);
+
+  const onHide = (): void => {
+    setModalOpen(!modalOpen);
+    navigate('/');
+  };
+
+  const onConfirm = (): void => {
+    importCourses(courses);
+    onHide();
+  };
+
+  return (
+    <Modal
+      className="import-courses-modal"
+      show={modalOpen}
+      onHide={onHide}
+      width={700}
+      buttonPrompt="Would you like to import these courses?"
+      buttons={[
+        {
+          label: 'No',
+          onClick: onHide,
+          cancel: true,
+        },
+        {
+          label: 'Yes',
+          onClick: onConfirm,
+        },
+      ]}
+    >
+      <Button className="remove-close-button" onClick={onHide}>
+        <FontAwesomeIcon icon={faXmark} size="xl" />
+      </Button>
+      <div className="import-courses-modal-content">
+        <div className="heading">Import Courses</div>
+        <div className="sub-heading">
+          You are about to import the following courses into your current
+          schedule:
+        </div>
+        <div className="courses-list">
+          {courses
+            .split(',')
+            .map((course) => normalizeCourseName(course.trim().toUpperCase()))
+            .filter((course) => course.length > 0)
+            .map((course, index) => (
+              <div key={index}>{course}</div>
+            ))}
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/ImportCoursesModal/stylesheet.scss
+++ b/src/components/ImportCoursesModal/stylesheet.scss
@@ -1,0 +1,45 @@
+@import '../../variables.scss';
+
+.import-courses-modal-content {
+  .heading {
+    font-size: 24px;
+    color: var(--theme-fg);
+    text-align: center;
+    font-weight: 700;
+  }
+
+  .courses-list {
+    margin-top: 15px;
+    font-size: 16px;
+    text-align: center;
+    color: var(--theme-fg);
+    font-weight: 500;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .sub-heading {
+    color: var(--theme-fg);
+    font-size: 14px;
+    padding-top: 15px;
+    text-align: center;
+  }
+
+  padding: 5% 10% 5% 10%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.remove-close-button {
+  width: 16px;
+  height: 16px;
+  position: absolute;
+  right: 12px;
+  top: 12px;
+  padding: 15px;
+  color: $color-neutral;
+  border-radius: 50px;
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -33,6 +33,7 @@ export { default as CourseNavMenu } from './CourseNavMenu';
 export { default as ComparisonContainer } from './ComparisonContainer';
 export { default as ComparisonPanel } from './ComparisonPanel';
 export { default as InviteBackLink } from './InviteBackLink';
+export { default as ImportCoursesModal } from './ImportCoursesModal';
 export { default as RouterComponent } from './RouterComponent';
 export { default as InvitationModal } from './InvitationModal';
 export { default as ShareIcon } from './ShareIcon';

--- a/src/hooks/useImportCourses.ts
+++ b/src/hooks/useImportCourses.ts
@@ -2,7 +2,7 @@ import { useCallback, useContext } from 'react';
 
 import { ScheduleContext } from '../contexts';
 import { ASYNC_DELIVERY_MODE } from '../constants';
-import { getRandomColor } from '../utils/misc';
+import { getRandomColor, normalizeCourseName } from '../utils/misc';
 
 /**
  * Hook to import courses from a comma-delimited string of course names.
@@ -35,8 +35,12 @@ export default function useImportCourses(): (courseString: string) => void {
 
       // Process each course name
       courseNames.forEach((courseName) => {
+        // Normalize the course name format (e.g., "CS1331" -> "CS 1331")
+        // Mitigate for different formatting of course string
+
+        const normalizedName = normalizeCourseName(courseName);
         // Search for the course in oscar.courses
-        const course = oscar.courses.find((c) => c.id === courseName);
+        const course = oscar.courses.find((c) => c.id === normalizedName);
 
         // If the course is found and not already in desiredCourses, add it
         if (course && !desiredCourses.includes(course.id)) {
@@ -71,7 +75,14 @@ export default function useImportCourses(): (courseString: string) => void {
         });
       }
     },
-    [oscar, desiredCourses, excludedCrns, colorMap, patchSchedule]
+    [
+      oscar.courses,
+      desiredCourses,
+      palette,
+      patchSchedule,
+      excludedCrns,
+      colorMap,
+    ]
   );
 
   return importCourses;

--- a/src/utils/misc.tsx
+++ b/src/utils/misc.tsx
@@ -553,3 +553,15 @@ export function abbreviateLocation(location: string): string {
 
   return location;
 }
+
+// Normalize Course Names
+// e.g. "cs1331" -> "CS 1331", "MATH 1551" -> "MATH 1551"
+export function normalizeCourseName(courseName: string): string {
+  let normalizedName = courseName;
+  const results = /^([A-Z]+)(\d.*)$/i.exec(courseName);
+  if (results != null) {
+    const [, subject, number] = results as unknown as [string, string, string];
+    normalizedName = `${subject} ${number}`;
+  }
+  return normalizedName;
+}


### PR DESCRIPTION
### Summary

Resolves #400 

https://www.gt-scheduler.org/#/?courses=CS1332,MATH3012

ImportCoursesModal should pop up. Then, a user can confirm or deny importing the courses. This will **append** to `desiredCourses` and it will not add courses that cannot be found in `oscar.courses`. 


### How to Test
Append `?courses=CS1332,MATH3012` to the deploy preview url.
https://www.gt-scheduler.org/pr-preview/pr-412/#/?courses=CS1332,MATH3012