### PR TITLE
Enable Course View Mode

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -123,7 +123,16 @@
     // Disable false positives for render props
     "react/no-unstable-nested-components": ["error", { "allowAsProps": true }],
     // Allow code like `<>{children}</>` to convert React.ReactNode => React.ReactElement
-    "react/jsx-no-useless-fragment": ["error", { "allowExpressions": true }]
+    "react/jsx-no-useless-fragment": ["error", { "allowExpressions": true }],
+    // Use ts version of no shadow
+    "no-shadow": "off",
+    "@typescript-eslint/no-shadow": [
+      "error",
+      {
+        "ignoreTypeValueShadow": true,
+        "ignoreFunctionTypeParameterNameValueShadow": true
+      }
+    ]
   },
   "overrides": [
     {

--- a/src/components/App/content.tsx
+++ b/src/components/App/content.tsx
@@ -12,12 +12,13 @@ import SurveyBanner from '../SurveyBanner';
 import {
   AppNavigationContext,
   AppMobileNav,
-  NAV_TABS,
   AppMobileNavDisplay,
 } from './navigation';
 import { classes } from '../../utils/misc';
 import { AccountContextValue } from '../../contexts/account';
 import { Term } from '../../types';
+
+export const WEB_NAV_TABS = ['Scheduler', 'Map', 'Finals'];
 
 /**
  * Renders the actual content at the root of the app
@@ -26,18 +27,17 @@ import { Term } from '../../types';
  * This component is memoized, so it only re-renders when its context changes.
  */
 function AppContentBase(): React.ReactElement {
-  const { currentTabIndex, setTabIndex, openDrawer } =
-    useContext(AppNavigationContext);
+  const { currentTab, setTab, openDrawer } = useContext(AppNavigationContext);
   const captureRef = useRef<HTMLDivElement>(null);
 
   return (
     <>
       <AppMobileNav captureRef={captureRef} />
       <Header
-        currentTab={currentTabIndex}
-        onChangeTab={setTabIndex}
+        currentTab={currentTab}
+        onChangeTab={setTab}
         onToggleMenu={openDrawer}
-        tabs={NAV_TABS}
+        tabs={WEB_NAV_TABS}
         captureRef={captureRef}
       />
       <SurveyBanner />
@@ -54,17 +54,19 @@ function AppContentBase(): React.ReactElement {
             >
               <div>
                 There was en error somewhere somewhere in the{' '}
-                {NAV_TABS[currentTabIndex] ?? '?'} tab and it can&apos;t
-                continue.
+                {currentTab ?? '?'} tab and it can&apos;t continue.
               </div>
               <div>Try refreshing the page to see if it fixes the issue.</div>
             </ErrorDisplay>
           </SkeletonContent>
         )}
       >
-        {currentTabIndex === 0 && <Scheduler />}
-        {currentTabIndex === 1 && <Map />}
-        {currentTabIndex === 2 && <Finals />}
+        {currentTab === 'Scheduler' && <Scheduler />}
+        {currentTab === 'Course details' && (
+          <span>Course Details Page Mobile placeholder</span>
+        )}
+        {currentTab === 'Map' && <Map />}
+        {currentTab === 'Finals' && <Finals />}
         {/* Fake calendar used to capture screenshots */}
         <div className="capture-container" ref={captureRef}>
           <Calendar className="fake-calendar" capture overlayCrns={[]} />
@@ -104,17 +106,16 @@ export function AppSkeleton({
   accountState,
   termsState,
 }: AppSkeletonProps): React.ReactElement {
-  const { currentTabIndex, setTabIndex, openDrawer } =
-    useContext(AppNavigationContext);
+  const { currentTab, setTab, openDrawer } = useContext(AppNavigationContext);
 
   return (
     <>
       <AppMobileNavDisplay />
       <HeaderDisplay
-        currentTab={currentTabIndex}
-        onChangeTab={setTabIndex}
+        currentTab={currentTab}
+        onChangeTab={setTab}
         onToggleMenu={openDrawer}
-        tabs={NAV_TABS}
+        tabs={WEB_NAV_TABS}
         accountState={accountState ?? { type: 'loading' }}
         termsState={
           termsState == null

--- a/src/components/App/navigation.tsx
+++ b/src/components/App/navigation.tsx
@@ -15,7 +15,7 @@ import { ErrorWithFields } from '../../log';
 import HeaderActionBar from '../HeaderActionBar';
 import { Course } from '../../data/beans';
 
-export const NAV_TABS = ['Scheduler', 'Map', 'Finals'];
+export const MOBILE_NAV_TABS = ['Scheduler', 'Course details', 'Map', 'Finals'];
 
 export enum SchedulerPageType {
   CALENDAR = 'calendar',
@@ -29,8 +29,8 @@ export type SchedulerPageState =
   | { type: SchedulerPageType.SECTION_DETAILS; course: Course };
 
 export type AppNavigationContextValue = {
-  currentTabIndex: number;
-  setTabIndex: (next: number) => void;
+  currentTab: string;
+  setTab: (next: string) => void;
   isDrawerOpen: boolean;
   openDrawer: () => void;
   closeDrawer: () => void;
@@ -40,10 +40,10 @@ export type AppNavigationContextValue = {
 
 export const AppNavigationContext =
   React.createContext<AppNavigationContextValue>({
-    currentTabIndex: 0,
-    setTabIndex: (): void => {
+    currentTab: 'Scheduler',
+    setTab: (): void => {
       throw new ErrorWithFields({
-        message: 'empty AppNavigationContext.setTabIndex value being used',
+        message: 'empty AppNavigationContext.setTab value being used',
       });
     },
     isDrawerOpen: false,
@@ -80,7 +80,7 @@ export function AppNavigation({
   const mobile = !useScreenWidth(DESKTOP_BREAKPOINT);
 
   // Allow top-level tab-based navigation
-  const [currentTabIndex, setTabIndex] = useState(0);
+  const [currentTab, setTab] = useState<string>('Scheduler');
 
   const [currentSchedulerPage, setCurrentSchedulerPage] =
     useState<SchedulerPageState>({ type: SchedulerPageType.CALENDAR });
@@ -99,8 +99,8 @@ export function AppNavigation({
   // Memoize the context value
   const contextValue = useMemo<AppNavigationContextValue>(
     () => ({
-      currentTabIndex,
-      setTabIndex,
+      currentTab,
+      setTab,
       isDrawerOpen,
       openDrawer,
       closeDrawer,
@@ -108,8 +108,8 @@ export function AppNavigation({
       setCurrentSchedulerPage,
     }),
     [
-      currentTabIndex,
-      setTabIndex,
+      currentTab,
+      setTab,
       isDrawerOpen,
       openDrawer,
       closeDrawer,
@@ -169,7 +169,7 @@ export function AppMobileNavDisplay({
 }: AppMobileNavDisplayProps): React.ReactElement | null {
   const mobile = !useScreenWidth(DESKTOP_BREAKPOINT);
   const largeMobile = useScreenWidth(LARGE_MOBILE_BREAKPOINT);
-  const { currentTabIndex, setTabIndex, isDrawerOpen, closeDrawer } =
+  const { currentTab, setTab, isDrawerOpen, closeDrawer } =
     useContext(AppNavigationContext);
 
   if (!mobile) return null;
@@ -190,10 +190,10 @@ export function AppMobileNavDisplay({
       )}
 
       <NavMenu
-        items={NAV_TABS}
-        currentItem={currentTabIndex}
+        items={MOBILE_NAV_TABS}
+        currentItem={currentTab}
         onChangeItem={(next): void => {
-          setTabIndex(next);
+          setTab(next);
           closeDrawer();
         }}
       />

--- a/src/components/App/navigation.tsx
+++ b/src/components/App/navigation.tsx
@@ -13,8 +13,20 @@ import { AccountContextValue } from '../../contexts/account';
 import useScreenWidth from '../../hooks/useScreenWidth';
 import { ErrorWithFields } from '../../log';
 import HeaderActionBar from '../HeaderActionBar';
+import { Course } from '../../data/beans';
 
 export const NAV_TABS = ['Scheduler', 'Map', 'Finals'];
+
+export enum SchedulerPageType {
+  CALENDAR = 'calendar',
+  COURSE_DETAILS = 'course-details',
+  SECTION_DETAILS = 'section-details',
+}
+
+export type SchedulerPageState =
+  | { type: SchedulerPageType.CALENDAR }
+  | { type: SchedulerPageType.COURSE_DETAILS }
+  | { type: SchedulerPageType.SECTION_DETAILS; course: Course };
 
 export type AppNavigationContextValue = {
   currentTabIndex: number;
@@ -22,6 +34,8 @@ export type AppNavigationContextValue = {
   isDrawerOpen: boolean;
   openDrawer: () => void;
   closeDrawer: () => void;
+  currentSchedulerPage: SchedulerPageState;
+  setCurrentSchedulerPage: (page: SchedulerPageState) => void;
 };
 
 export const AppNavigationContext =
@@ -43,6 +57,13 @@ export const AppNavigationContext =
         message: 'empty AppNavigationContext.closeDrawer value being used',
       });
     },
+    currentSchedulerPage: { type: SchedulerPageType.CALENDAR },
+    setCurrentSchedulerPage: (): void => {
+      throw new ErrorWithFields({
+        message:
+          'empty AppNavigationContext.setCurrentSchedulerPage value being used',
+      });
+    },
   });
 
 export type AppNavigationProps = {
@@ -60,6 +81,9 @@ export function AppNavigation({
 
   // Allow top-level tab-based navigation
   const [currentTabIndex, setTabIndex] = useState(0);
+
+  const [currentSchedulerPage, setCurrentSchedulerPage] =
+    useState<SchedulerPageState>({ type: SchedulerPageType.CALENDAR });
 
   // Handle the status of the drawer being open on mobile
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
@@ -80,8 +104,18 @@ export function AppNavigation({
       isDrawerOpen,
       openDrawer,
       closeDrawer,
+      currentSchedulerPage,
+      setCurrentSchedulerPage,
     }),
-    [currentTabIndex, setTabIndex, isDrawerOpen, openDrawer, closeDrawer]
+    [
+      currentTabIndex,
+      setTabIndex,
+      isDrawerOpen,
+      openDrawer,
+      closeDrawer,
+      currentSchedulerPage,
+      setCurrentSchedulerPage,
+    ]
   );
 
   return (

--- a/src/components/App/stylesheet.scss
+++ b/src/components/App/stylesheet.scss
@@ -21,13 +21,13 @@
     display: flex;
     align-items: stretch;
 
-    .calendar-container {
+    .scheduler-container {
       flex: 1;
       display: flex;
       flex-direction: column;
       align-items: stretch;
       overflow-y: auto;
-
+      gap: 20px;
       .calendar {
         min-height: $calendar-height;
       }
@@ -127,11 +127,11 @@ body.light .App {
           line-height: 28px;
 
           span {
-            color: #C56E5B;
+            color: #c56e5b;
           }
-          
+
           a {
-            color: #C56E5B;
+            color: #c56e5b;
           }
         }
       }
@@ -144,7 +144,7 @@ body.light .App {
     .footer {
       position: absolute;
       bottom: 32px;
-      
+
       img {
         width: 200px;
       }
@@ -186,7 +186,7 @@ body.light .App {
 
     .footer {
       bottom: 18px;
-      
+
       img {
         width: 150px;
       }

--- a/src/components/Calendar/stylesheet.scss
+++ b/src/components/Calendar/stylesheet.scss
@@ -1,14 +1,14 @@
 @import '../../variables';
 
 @mixin calendar-margin($calendar-margin, $hidden-sections-margin) {
-  margin-top: $day-height + $calendar-margin;
+  margin-top: $day-height;
   margin-right: $calendar-margin;
   margin-bottom: $hidden-sections-margin + $calendar-margin;
   margin-left: $time-width + $calendar-margin;
 }
 
 .Calendar {
-  @include calendar-margin(24px, 16px);
+  @include calendar-margin($calendar-web-margin, 16px);
   flex: 1;
   position: relative;
   height: $calendar-height;
@@ -46,7 +46,7 @@
         display: block;
         width: $time-width;
         padding-right: 8px;
-        font-size: .8em;
+        font-size: 0.8em;
         font-weight: bold;
         text-align: right;
       }
@@ -98,8 +98,6 @@
     }
   }
 
-  .meeting {}
-
   .hidden-sections {
     max-width: fit-content;
     padding-top: 10px;
@@ -107,7 +105,7 @@
     align-self: self-start;
     display: flex !important;
     flex-wrap: wrap;
-    font-size: .8em;
+    font-size: 0.8em;
     position: relative !important;
     top: 100% !important;
   }

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -9,8 +9,8 @@ import { DEFAULT_PALETTE, SOFT_PALETTE, DEEP_PALETTE } from '../../constants';
 import './stylesheet.scss';
 
 export type HeaderProps = {
-  currentTab: number;
-  onChangeTab: (newTab: number) => void;
+  currentTab: string;
+  onChangeTab: (newTab: string) => void;
   onToggleMenu: () => void;
   tabs: string[];
   captureRef: React.RefObject<HTMLDivElement>;

--- a/src/components/HeaderDisplay/index.tsx
+++ b/src/components/HeaderDisplay/index.tsx
@@ -60,8 +60,8 @@ type PaletteState =
 
 export type HeaderDisplayProps = {
   totalCredits?: number | null;
-  currentTab: number;
-  onChangeTab: (newTab: number) => void;
+  currentTab: string;
+  onChangeTab: (newTab: string) => void;
   onToggleMenu: () => void;
   tabs: string[];
   onCopyCrns?: () => void;
@@ -198,8 +198,8 @@ export default function HeaderDisplay({
           {tabs.map((tabLabel, tabIdx) => (
             <Tab
               key={tabIdx}
-              active={tabIdx === currentTab}
-              onClick={(): void => onChangeTab(tabIdx)}
+              active={tabLabel === currentTab}
+              onClick={(): void => onChangeTab(tabLabel)}
               label={tabLabel}
             />
           ))}

--- a/src/components/NavMenu/index.tsx
+++ b/src/components/NavMenu/index.tsx
@@ -7,8 +7,8 @@ import './stylesheet.scss';
 
 export type NavMenuProps = {
   items: string[];
-  currentItem: number;
-  onChangeItem: (next: number) => void;
+  currentItem: string;
+  onChangeItem: (next: string) => void;
   className?: string;
   style?: React.CSSProperties;
 };
@@ -27,8 +27,8 @@ export default function NavMenu({
     <div className={classes('nav-menu', className)} style={style}>
       {items.map((item, idx) => (
         <Button
-          className={classes('nav-button', currentItem === idx && 'active')}
-          onClick={(): void => onChangeItem(idx)}
+          className={classes('nav-button', currentItem === item && 'active')}
+          onClick={(): void => onChangeItem(item)}
           key={idx}
         >
           {item}

--- a/src/components/ScheduleContainer/index.tsx
+++ b/src/components/ScheduleContainer/index.tsx
@@ -1,0 +1,101 @@
+import React, { ReactElement, useCallback, useContext, useMemo } from 'react';
+import { faCalendar, faInfoCircle } from '@fortawesome/free-solid-svg-icons';
+
+import { Calendar } from '..';
+import TabBar from '../TabBar';
+import {
+  AppNavigationContext,
+  SchedulerPageState,
+  SchedulerPageType,
+} from '../App/navigation';
+
+type ScheduleContainerProps = {
+  overlayCrns: string[];
+  compare: boolean;
+  pinnedFriendSchedules: string[];
+  pinSelf: boolean;
+  overlaySchedules: string[];
+  mobile: boolean;
+};
+
+type SchedulerTabType =
+  | SchedulerPageType.CALENDAR
+  | SchedulerPageType.COURSE_DETAILS;
+
+const TABS = [
+  { key: SchedulerPageType.CALENDAR, label: 'Calendar', icon: faCalendar },
+  {
+    key: SchedulerPageType.COURSE_DETAILS,
+    label: 'Course Details',
+    icon: faInfoCircle,
+  },
+] as const;
+
+export default function ScheduleContainer({
+  overlayCrns,
+  compare,
+  pinnedFriendSchedules,
+  pinSelf,
+  overlaySchedules,
+  mobile,
+}: ScheduleContainerProps): React.ReactElement {
+  const { currentSchedulerPage, setCurrentSchedulerPage } =
+    useContext(AppNavigationContext);
+
+  const selectedTab = useMemo(
+    () => TABS.find((tab) => tab.key === currentSchedulerPage.type) ?? TABS[0],
+    [currentSchedulerPage.type]
+  );
+
+  const handleTabSelect = useCallback(
+    (key: SchedulerTabType) => {
+      setCurrentSchedulerPage({ type: key });
+    },
+    [setCurrentSchedulerPage]
+  );
+
+  function renderSchedulerPage(
+    schedulerPage: SchedulerPageState
+  ): ReactElement | null {
+    switch (schedulerPage.type) {
+      case SchedulerPageType.CALENDAR:
+        return (
+          <div className="calendar-container">
+            <Calendar
+              className="calendar"
+              overlayCrns={overlayCrns}
+              compare={compare}
+              pinnedFriendSchedules={pinnedFriendSchedules}
+              pinSelf={!compare || pinSelf}
+              overlayFriendSchedules={overlaySchedules}
+            />
+          </div>
+        );
+
+      case SchedulerPageType.COURSE_DETAILS:
+        return <span>Course details page placeholder</span>;
+
+      default:
+        return null;
+    }
+  }
+
+  return (
+    <div className="scheduler-container">
+      {!mobile && (
+        <div className="view-mode">
+          <span className="view-mode-label">View Mode:</span>
+          <TabBar
+            className="view-mode-tab-bar"
+            enableSelect
+            items={TABS}
+            selected={selectedTab}
+            onSelect={handleTabSelect}
+          />
+        </div>
+      )}
+
+      {renderSchedulerPage(currentSchedulerPage)}
+    </div>
+  );
+}

--- a/src/components/ScheduleContainer/index.tsx
+++ b/src/components/ScheduleContainer/index.tsx
@@ -73,7 +73,7 @@ export default function ScheduleContainer({
         );
 
       case SchedulerPageType.COURSE_DETAILS:
-        return <span>Course details page placeholder</span>;
+        return <span>Course details page web placeholder</span>;
 
       default:
         return null;

--- a/src/components/Scheduler/index.tsx
+++ b/src/components/Scheduler/index.tsx
@@ -3,7 +3,6 @@ import React, { useCallback, useContext, useMemo, useState } from 'react';
 import { classes } from '../../utils/misc';
 import {
   Button,
-  Calendar,
   CombinationContainer,
   ComparisonPanel,
   CourseContainer,
@@ -16,6 +15,9 @@ import {
 import { DESKTOP_BREAKPOINT } from '../../constants';
 import useCompareStateFromStorage from '../../data/hooks/useCompareStateFromStorage';
 import useScreenWidth from '../../hooks/useScreenWidth';
+import ScheduleContainer from '../ScheduleContainer';
+
+import './stylesheet.scss';
 
 /**
  * Wraps around the root top-level component of the Scheduler tab
@@ -77,16 +79,14 @@ export default function Scheduler(): React.ReactElement {
           {(!mobile || tabIndex === 0) && <CourseContainer />}
           {mobile && tabIndex === 1 && <CombinationContainer />}
           {(!mobile || tabIndex === 2) && (
-            <div className="calendar-container">
-              <Calendar
-                className="calendar"
-                overlayCrns={overlayCrns}
-                compare={compare}
-                pinnedFriendSchedules={pinned}
-                pinSelf={!compare || pinSelf}
-                overlayFriendSchedules={overlaySchedules}
-              />
-            </div>
+            <ScheduleContainer
+              overlayCrns={overlayCrns}
+              compare={compare}
+              pinnedFriendSchedules={pinned}
+              pinSelf={!compare || pinSelf}
+              overlaySchedules={overlaySchedules}
+              mobile={mobile}
+            />
           )}
           {(!mobile || tabIndex === 3) && (
             <ComparisonPanel

--- a/src/components/Scheduler/stylesheet.scss
+++ b/src/components/Scheduler/stylesheet.scss
@@ -1,0 +1,15 @@
+@import '../../variables';
+
+.view-mode {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-left: $calendar-web-margin;
+  margin-top: $calendar-web-margin;
+
+  .view-mode-label {
+    font-size: 1em;
+    font-weight: bold;
+    font-family: 'Roboto';
+  }
+}

--- a/src/components/TabBar/index.tsx
+++ b/src/components/TabBar/index.tsx
@@ -1,0 +1,90 @@
+import React, { useRef, useState, useEffect } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+
+import { classes } from '../../utils/misc';
+
+import './stylesheet.scss';
+
+export type TabBarItem<K extends string> = {
+  key: K;
+  label: string;
+  icon?: IconDefinition;
+};
+
+type TabBarProps<K extends string> = {
+  className?: string;
+  enableSelect?: boolean;
+  items: readonly TabBarItem<K>[];
+  selected?: TabBarItem<K>;
+  onSelect?: (key: K) => void;
+};
+
+export default function TabBar<K extends string>({
+  className,
+  enableSelect = false,
+  items,
+  selected,
+  onSelect,
+}: TabBarProps<K>): React.ReactElement {
+  const ref = useRef<HTMLDivElement>(null);
+  const [fadeLeft, setFadeLeft] = useState(false);
+  const [fadeRight, setFadeRight] = useState(false);
+
+  useEffect(() => {
+    if (!enableSelect) return;
+    const el = ref.current;
+    if (!el) return;
+
+    const checkScroll = (): void => {
+      const isOverflowing = el.scrollWidth > el.clientWidth;
+      const atStart = el.scrollLeft <= 0;
+      const atEnd = el.scrollLeft + el.clientWidth >= el.scrollWidth - 1;
+      setFadeLeft(isOverflowing && !atStart);
+      setFadeRight(isOverflowing && !atEnd);
+    };
+
+    checkScroll();
+    el.addEventListener('scroll', checkScroll);
+    window.addEventListener('resize', checkScroll);
+    return () => {
+      el.removeEventListener('scroll', checkScroll);
+      window.removeEventListener('resize', checkScroll);
+    };
+  }, [items, enableSelect]);
+
+  return (
+    <div className="TabBarContainer">
+      {enableSelect && fadeLeft && <div className="fade-left" />}
+      <div
+        ref={ref}
+        className={classes(
+          'TabBar',
+          !enableSelect && 'unselectable',
+          className
+        )}
+      >
+        {items.map((item) => {
+          const isActive = selected?.key === item.key;
+          return (
+            <div
+              key={item.key}
+              className={classes('tab', enableSelect && isActive && 'active')}
+              onClick={(): void => {
+                if (enableSelect && onSelect) {
+                  onSelect(item.key);
+                }
+              }}
+            >
+              {item.icon && (
+                <FontAwesomeIcon icon={item.icon} className="tab-icon" />
+              )}
+              <span className="tab-label">{item.label}</span>
+            </div>
+          );
+        })}
+      </div>
+      {enableSelect && fadeRight && <div className="fade-right" />}
+    </div>
+  );
+}

--- a/src/components/TabBar/index.tsx
+++ b/src/components/TabBar/index.tsx
@@ -1,7 +1,8 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useRef } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 
+import useScrollFade from '../../hooks/useScrollFade';
 import { classes } from '../../utils/misc';
 
 import './stylesheet.scss';
@@ -28,30 +29,12 @@ export default function TabBar<K extends string>({
   onSelect,
 }: TabBarProps<K>): React.ReactElement {
   const ref = useRef<HTMLDivElement>(null);
-  const [fadeLeft, setFadeLeft] = useState(false);
-  const [fadeRight, setFadeRight] = useState(false);
+  const { fadeLeft, fadeRight } = useScrollFade(ref, enableSelect);
 
-  useEffect(() => {
+  const handleSelect = (key: K): void => {
     if (!enableSelect) return;
-    const el = ref.current;
-    if (!el) return;
-
-    const checkScroll = (): void => {
-      const isOverflowing = el.scrollWidth > el.clientWidth;
-      const atStart = el.scrollLeft <= 0;
-      const atEnd = el.scrollLeft + el.clientWidth >= el.scrollWidth - 1;
-      setFadeLeft(isOverflowing && !atStart);
-      setFadeRight(isOverflowing && !atEnd);
-    };
-
-    checkScroll();
-    el.addEventListener('scroll', checkScroll);
-    window.addEventListener('resize', checkScroll);
-    return () => {
-      el.removeEventListener('scroll', checkScroll);
-      window.removeEventListener('resize', checkScroll);
-    };
-  }, [items, enableSelect]);
+    onSelect?.(key);
+  };
 
   return (
     <div className="TabBarContainer">
@@ -70,11 +53,7 @@ export default function TabBar<K extends string>({
             <div
               key={item.key}
               className={classes('tab', enableSelect && isActive && 'active')}
-              onClick={(): void => {
-                if (enableSelect && onSelect) {
-                  onSelect(item.key);
-                }
-              }}
+              onClick={(): void => handleSelect(item.key)}
             >
               {item.icon && (
                 <FontAwesomeIcon icon={item.icon} className="tab-icon" />

--- a/src/components/TabBar/stylesheet.scss
+++ b/src/components/TabBar/stylesheet.scss
@@ -1,0 +1,94 @@
+@import '../../variables';
+
+.TabBarContainer {
+  position: relative;
+  overflow: hidden;
+}
+
+.TabBar {
+  display: flex;
+  align-items: center;
+  background-color: $buttons-secondary-action-dark;
+  border-radius: 10px;
+  padding: 4px;
+  overflow-x: auto;
+  scroll-behavior: smooth;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  .tab {
+    min-width: 128px;
+    padding: 14px;
+    height: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: 'Roboto', sans-serif;
+    font-size: 0.875em;
+    border-radius: 6px;
+    cursor: pointer;
+    color: $buttons-secondary-action;
+    white-space: nowrap;
+    transition: background-color 0.2s, color 0.2s, opacity 0.2s;
+    gap: 8px;
+
+    &.active {
+      background-color: rgba($color-neutral, 0.3);
+      @include dark(color, $theme-light-background);
+      @include light(color, $theme-dark-background);
+      font-weight: bold;
+    }
+  }
+
+  &.unselectable {
+    flex-wrap: wrap;
+    overflow-x: visible;
+    justify-content: flex-start;
+    .tab {
+      color: white;
+      cursor: default;
+      opacity: 1;
+    }
+  }
+}
+
+.fade-right,
+.fade-left {
+  position: absolute;
+  top: 0;
+  width: 40px;
+  height: 100%;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.fade-right {
+  right: 0;
+  background: linear-gradient(
+    to right,
+    rgba($buttons-secondary-action-dark, 0),
+    rgba($buttons-secondary-action-dark, 1)
+  );
+  border-radius: 0 10px 10px 0;
+}
+
+.fade-left {
+  left: 0;
+  background: linear-gradient(
+    to left,
+    rgba($buttons-secondary-action-dark, 0),
+    rgba($buttons-secondary-action-dark, 1)
+  );
+  border-radius: 10px 0 0 10px;
+}
+
+@media (max-width: 600px) {
+  .TabBar {
+    .tab {
+      margin-right: 0;
+    }
+  }
+}

--- a/src/components/TabBar/stylesheet.scss
+++ b/src/components/TabBar/stylesheet.scss
@@ -11,7 +11,6 @@
   background-color: $buttons-secondary-action-dark;
   border-radius: 10px;
   padding: 4px;
-  overflow-x: auto;
   scroll-behavior: smooth;
   scrollbar-width: none;
   -ms-overflow-style: none;
@@ -31,7 +30,6 @@
     border-radius: 6px;
     cursor: pointer;
     color: $buttons-secondary-action;
-    white-space: nowrap;
     transition: background-color 0.2s, color 0.2s, opacity 0.2s;
     gap: 8px;
 
@@ -48,7 +46,7 @@
     overflow-x: visible;
     justify-content: flex-start;
     .tab {
-      color: white;
+      color: $theme-light-background;
       cursor: default;
       opacity: 1;
     }
@@ -83,12 +81,4 @@
     rgba($buttons-secondary-action-dark, 1)
   );
   border-radius: 10px 0 0 10px;
-}
-
-@media (max-width: 600px) {
-  .TabBar {
-    .tab {
-      margin-right: 0;
-    }
-  }
 }

--- a/src/hooks/useScrollFade.ts
+++ b/src/hooks/useScrollFade.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+
+export default function useScrollFade(
+  ref: React.RefObject<HTMLElement>,
+  enabled: boolean
+): { fadeLeft: boolean; fadeRight: boolean } {
+  const [fadeLeft, setFadeLeft] = useState(false);
+  const [fadeRight, setFadeRight] = useState(false);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const el = ref.current;
+    if (!el) return;
+
+    const update = (): void => {
+      const { scrollLeft, scrollWidth, clientWidth } = el;
+      const isOverflowing = scrollWidth > clientWidth;
+      setFadeLeft(isOverflowing && scrollLeft > 0);
+      setFadeRight(isOverflowing && scrollLeft + clientWidth < scrollWidth - 1);
+    };
+
+    update();
+    el.addEventListener('scroll', update);
+    window.addEventListener('resize', update);
+
+    return () => {
+      el.removeEventListener('scroll', update);
+      window.removeEventListener('resize', update);
+    };
+  }, [enabled, ref]);
+
+  return { fadeLeft, fadeRight };
+}

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -3,6 +3,7 @@ $calendar-width: 720px;
 $time-width: 48px;
 $day-height: 40px;
 $header-height: 64px;
+$calendar-web-margin: 24px;
 
 $desktop-breakpoint: 1024px;
 $large-mobile-breakpoint: 600px;
@@ -16,8 +17,8 @@ $theme-dark-card-background: #434343;
 $theme-light-foreground: $theme-dark-background;
 $theme-dark-foreground: $theme-light-background;
 $color-background-light: #f8f9fa;
-$account-accent: #0C797D;
-$travel-time-blue: #589BD5;
+$account-accent: #0c797d;
+$travel-time-blue: #589bd5;
 
 $toggle-background-dark: rgba(15, 23, 42, 0.85);
 $toggle-background-active-dark: rgba(15, 23, 42, 0.95);
@@ -39,8 +40,12 @@ $modal-foreground-color-light: #555555;
 $modal-strong-foreground-color-dark: #dddddd;
 $modal-strong-foreground-color-light: #444444;
 
-$seat-info-dark-label: rgba(255, 255, 255, 0.50);
+$seat-info-dark-label: rgba(255, 255, 255, 0.5);
 $seat-info-light-label: #848173;
+
+$buttons-secondary-action: #676767;
+$buttons-secondary-action-dark: #2a2a2a;
+$buttons-secondary-gradient-dark: #323232;
 
 @mixin card {
   box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14),


### PR DESCRIPTION
### Summary
As part of the new Course Details Page, we want to enable a new toggle to view course details. This PR adds the ability to toggle to a new context as well as creates the components necessary for the visual aspect of this (the button).

Currently we use a placeholder for the course details page before we go ahead with the implementation.

Note that we are still waiting on light mode designs (eta next week) so this only works on dark. 

For mobile to avoid problems with indices I also changed the way we did tabs (using indices) to using values (strings so not bulky and equality holds).

### How to Test
[Deploy Preview](https://gt-scheduler.github.io/website/pr-preview/pr-419/)

`yarn start`

<img width="1787" height="858" alt="image" src="https://github.com/user-attachments/assets/a6f593ae-c9cd-41ec-8333-9bd92b486d43" />
<img width="1892" height="855" alt="image" src="https://github.com/user-attachments/assets/7f7d0eda-8b2f-4100-a372-1fe560fac93d" />


Mobile
<img width="352" height="617" alt="image" src="https://github.com/user-attachments/assets/c84799b2-8be3-4bdc-84c6-80268cb1e5ca" />


