### PR TITLE
Short Course Info Details

### DIFF
--- a/src/components/Card/stylesheet.scss
+++ b/src/components/Card/stylesheet.scss
@@ -3,8 +3,8 @@
 .CardContainer {
   display: flex;
   flex-direction: column;
-  background-color: $theme-dark-card-background;
-  border-left: 8px solid $theme-dark-card-background;
+  background-color: $theme-dark-background-foreground;
+  border-left: 8px solid $theme-dark-background-foreground;
   border-radius: 5px;
   padding: 20px;
 }

--- a/src/components/CourseInfo/index.tsx
+++ b/src/components/CourseInfo/index.tsx
@@ -6,7 +6,7 @@ import { CrawlerPrerequisites } from '../../types';
 import MetricsCard from '../MetricsCard';
 import TabBar from '../TabBar';
 import { ErrorWithFields, softError } from '../../log';
-import { getTermFromSemesterName } from '../../utils/semesters';
+import { getSemesterName } from '../../utils/semesters';
 
 import './stylesheet.scss';
 
@@ -59,7 +59,7 @@ export default function CourseInfo({
    * Note that course critique as of Spr2025 only has data up to Spr2024
    * This can make it incomplete (ie. From Spring 2025 to Spring 2024)
    */
-  const offered_terms = useMemo(() => {
+  const offeredTerms = useMemo(() => {
     const termInfo = course?.termInfo;
     const currentTerm = course?.term;
 
@@ -67,13 +67,10 @@ export default function CourseInfo({
 
     return Object.keys(termInfo)
       .filter((termKey) => {
-        const termValue = getTermFromSemesterName(termKey) ?? '';
-        return termValue.localeCompare(currentTerm) <= 0;
+        return termKey.localeCompare(currentTerm) <= 0;
       })
       .sort((a, b) => {
-        return (getTermFromSemesterName(b) ?? '').localeCompare(
-          getTermFromSemesterName(a) ?? ''
-        );
+        return b.localeCompare(a);
       })
       .slice(0, 6);
   }, [course, isLoaded]);
@@ -145,15 +142,15 @@ export default function CourseInfo({
           </ul>
         </div>
       </div>
-      {offered_terms.length > 0 && (
+      {offeredTerms.length > 0 && (
         <div className="course-terms">
           <div className="course-info-subtitle">Offered Terms</div>
           <div>
             <TabBar
               className="course-terms-tab-bar"
-              items={offered_terms.map((term) => ({
+              items={offeredTerms.map((term) => ({
                 key: term,
-                label: term,
+                label: getSemesterName(term, true),
               }))}
             />
           </div>

--- a/src/components/CourseInfo/index.tsx
+++ b/src/components/CourseInfo/index.tsx
@@ -4,11 +4,11 @@ import { ScheduleContext } from '../../contexts';
 import { serializePrereqs } from '../../utils/misc';
 import { CrawlerPrerequisites } from '../../types';
 import MetricsCard from '../MetricsCard';
+import TabBar from '../TabBar';
+import { ErrorWithFields, softError } from '../../log';
 import { getTermFromSemesterName } from '../../utils/semesters';
 
 import './stylesheet.scss';
-import TabBar from '../TabBar';
-import { ErrorWithFields, softError } from '../../log';
 
 export type CourseInfoProps = {
   courseId: string;
@@ -42,7 +42,7 @@ export default function CourseInfo({
           );
         });
     }
-  }, [course]);
+  }, [course, courseId]);
 
   const prerequisite = useMemo(() => {
     return course?.prereqs
@@ -54,7 +54,7 @@ export default function CourseInfo({
   const credits = useMemo(() => course?.sections?.[0]?.credits, [course]);
 
   /**
-   * Get the currterm + 5 terms prior to the current term in course crit response
+   * Get the currterm + 5 terms prior to current term in course crit response
    *
    * Note that course critique as of Spr2025 only has data up to Spr2024
    * This can make it incomplete (ie. From Spring 2025 to Spring 2024)

--- a/src/components/CourseInfo/index.tsx
+++ b/src/components/CourseInfo/index.tsx
@@ -1,11 +1,14 @@
-import React, { useContext, useMemo } from 'react';
+import React, { useContext, useEffect, useMemo, useState } from 'react';
 
 import { ScheduleContext } from '../../contexts';
 import { serializePrereqs } from '../../utils/misc';
 import { CrawlerPrerequisites } from '../../types';
 import MetricsCard from '../MetricsCard';
+import { getTermFromSemesterName } from '../../utils/semesters';
 
 import './stylesheet.scss';
+import TabBar from '../TabBar';
+import { ErrorWithFields, softError } from '../../log';
 
 export type CourseInfoProps = {
   courseId: string;
@@ -16,12 +19,64 @@ export default function CourseInfo({
 }: CourseInfoProps): React.ReactElement {
   const [{ oscar }] = useContext(ScheduleContext);
   const course = useMemo(() => oscar.findCourse(courseId), [oscar, courseId]);
+
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    if (course) {
+      course
+        .fetchGpa()
+        .then(() => {
+          setIsLoaded(true);
+        })
+        .catch((err) => {
+          softError(
+            new ErrorWithFields({
+              message: 'error fetching course GPA',
+              source: err,
+              fields: {
+                courseId,
+                term: course.term,
+              },
+            })
+          );
+        });
+    }
+  }, [course]);
+
   const prerequisite = useMemo(() => {
     return course?.prereqs
-      ? serializePrereqs(course.prereqs as Exclude<CrawlerPrerequisites, []>)
+      ? serializePrereqs(
+          course.prereqs as Exclude<CrawlerPrerequisites, []>
+        ).replace(/^\(|\)$/g, '')
       : 'None';
   }, [course?.prereqs]);
   const credits = useMemo(() => course?.sections?.[0]?.credits, [course]);
+
+  /**
+   * Get the currterm + 5 terms prior to the current term in course crit response
+   *
+   * Note that course critique as of Spr2025 only has data up to Spr2024
+   * This can make it incomplete (ie. From Spring 2025 to Spring 2024)
+   */
+  const offered_terms = useMemo(() => {
+    const termInfo = course?.termInfo;
+    const currentTerm = course?.term;
+
+    if (!termInfo || !currentTerm || !isLoaded) return [];
+
+    return Object.keys(termInfo)
+      .filter((termKey) => {
+        const termValue = getTermFromSemesterName(termKey) ?? '';
+        return termValue.localeCompare(currentTerm) <= 0;
+      })
+      .sort((a, b) => {
+        return (getTermFromSemesterName(b) ?? '').localeCompare(
+          getTermFromSemesterName(a) ?? ''
+        );
+      })
+      .slice(0, 6);
+  }, [course, isLoaded]);
 
   if (!course) {
     return <div />;
@@ -90,10 +145,20 @@ export default function CourseInfo({
           </ul>
         </div>
       </div>
-      <div className="course-terms">
-        <div className="course-info-subtitle">Offered Terms</div>
-        <div>course terms placeholder</div>
-      </div>
+      {offered_terms.length > 0 && (
+        <div className="course-terms">
+          <div className="course-info-subtitle">Offered Terms</div>
+          <div>
+            <TabBar
+              className="course-terms-tab-bar"
+              items={offered_terms.map((term) => ({
+                key: term,
+                label: term,
+              }))}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/CourseInfo/index.tsx
+++ b/src/components/CourseInfo/index.tsx
@@ -65,7 +65,7 @@ export default function CourseInfo({
         <div className="course-metrics">
           <MetricsCard metrics={metrics} />
         </div>
-        <div>course description placeholder</div>
+        <div>{course?.description || 'No description available'}</div>
         <div className="course-eligibility">
           <div className="course-info-subtitle">Eligibility</div>
           <ul className="course-eligibility-content">
@@ -82,7 +82,9 @@ export default function CourseInfo({
                 <div className="course-eligibility-content-title">
                   Corequisites
                 </div>
-                corequisite placeholder
+                {course.coreqs && course.coreqs.length > 0
+                  ? course.coreqs.map((coreq) => coreq.id).join(', ')
+                  : 'None'}
               </div>
             </li>
           </ul>

--- a/src/components/CourseInfo/stylesheet.scss
+++ b/src/components/CourseInfo/stylesheet.scss
@@ -1,3 +1,5 @@
+@import '../../variables.scss';
+
 .course-info-subtitle {
   font-weight: bold;
 }
@@ -60,6 +62,10 @@
     display: flex;
     flex-direction: column;
     gap: 20px;
+
+    .course-terms-tab-bar {
+      background-color: $buttons-navigation-hover;
+    }
   }
 }
 

--- a/src/components/Scheduler/stylesheet.scss
+++ b/src/components/Scheduler/stylesheet.scss
@@ -11,4 +11,8 @@
     font-size: 1em;
     font-weight: bold;
   }
+
+  .view-mode-tab-bar {
+    font-size: 0.875em;
+  }
 }

--- a/src/components/TabBar/stylesheet.scss
+++ b/src/components/TabBar/stylesheet.scss
@@ -25,8 +25,6 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    font-family: 'Roboto', sans-serif;
-    font-size: 0.875em;
     border-radius: 6px;
     cursor: pointer;
     color: $buttons-secondary-action;

--- a/src/data/beans/Course.ts
+++ b/src/data/beans/Course.ts
@@ -17,7 +17,7 @@ import {
 } from '../../utils/misc';
 import { ErrorWithFields, softError } from '../../log';
 import { CLOUD_FUNCTION_BASE_URL } from '../../constants';
-import { getSemesterName } from '../../utils/semesters';
+import { getTermFromSemesterName } from '../../utils/semesters';
 
 // This is actually a transparent read-through cache
 // in front of the Course Critique API's course data endpoint,
@@ -120,7 +120,7 @@ export default class Course {
       }
     );
     this.termInfo = {
-      [getSemesterName(this.term)]: this.sections.flatMap((s) => s.instructors),
+      [this.term]: this.sections.flatMap((s) => s.instructors),
     };
     this.prereqs = prereqs;
     this.coreqs = coreqs;
@@ -419,11 +419,13 @@ export default class Course {
         instructorGpa.sum += gpa * classSizeEstimate;
         instructors.set(instructorName, instructorGpa);
 
-        const termKey = String(historicalTerm);
-        this.termInfo[termKey] ??= [];
-        const termInstructors = this.termInfo[termKey];
-        if (termInstructors && !termInstructors.includes(instructorName)) {
-          termInstructors.push(instructorName);
+        const termKey = getTermFromSemesterName(String(historicalTerm));
+        if (termKey) {
+          this.termInfo[termKey] ??= [];
+          const termInstructors = this.termInfo[termKey];
+          if (termInstructors && !termInstructors.includes(instructorName)) {
+            termInstructors.push(instructorName);
+          }
         }
       });
 

--- a/src/data/beans/Course.ts
+++ b/src/data/beans/Course.ts
@@ -4,6 +4,7 @@ import { decode } from 'html-entities';
 import { Oscar, Section } from '.';
 import {
   CourseGpa,
+  CrawlerCorequisites,
   CrawlerCourse,
   CrawlerPrerequisites,
   Period,
@@ -50,9 +51,13 @@ export default class Course {
 
   title: string;
 
+  description?: string;
+
   sections: Section[];
 
   prereqs: CrawlerPrerequisites | undefined;
+
+  coreqs: CrawlerCorequisites | undefined;
 
   hasLab: boolean;
 
@@ -71,7 +76,7 @@ export default class Course {
   constructor(oscar: Oscar, courseId: string, data: CrawlerCourse) {
     this.term = oscar.term;
     this.plannedCount = oscar.plannedCounts?.courseCounts[courseId];
-    const [title, sections, prereqs] = data;
+    const [title, sections, prereqs, description, coreqs] = data;
 
     this.id = courseId;
     const [subject, number] = this.id.split(' ');
@@ -90,6 +95,7 @@ export default class Course {
     this.number = number;
 
     this.title = decode(title);
+    this.description = description ? decode(description) : undefined;
     this.sections = Object.entries(sections).flatMap<Section>(
       ([sectionId, sectionData]) => {
         if (sectionData == null) return [];
@@ -111,6 +117,7 @@ export default class Course {
       }
     );
     this.prereqs = prereqs;
+    this.coreqs = coreqs;
 
     const onlyLectures = this.sections.filter(
       (section) => isLecture(section) && !isLab(section)

--- a/src/data/beans/Course.ts
+++ b/src/data/beans/Course.ts
@@ -17,6 +17,7 @@ import {
 } from '../../utils/misc';
 import { ErrorWithFields, softError } from '../../log';
 import { CLOUD_FUNCTION_BASE_URL } from '../../constants';
+import { getSemesterName } from '../../utils/semesters';
 
 // This is actually a transparent read-through cache
 // in front of the Course Critique API's course data endpoint,
@@ -25,7 +26,7 @@ import { CLOUD_FUNCTION_BASE_URL } from '../../constants';
 // https://github.com/gt-scheduler/firebase-conf/blob/main/functions/src/course_critique_cache.ts
 const COURSE_CRITIQUE_API_URL = `${CLOUD_FUNCTION_BASE_URL}/getCourseDataFromCourseCritique`;
 
-const GPA_CACHE_LOCAL_STORAGE_KEY = 'course-gpa-cache-2';
+const GPA_CACHE_LOCAL_STORAGE_KEY = 'course-gpa-cache-3';
 const GPA_CACHE_EXPIRATION_DURATION_DAYS = 7;
 
 interface SectionGroupMeeting {
@@ -70,6 +71,8 @@ export default class Course {
   sectionGroups: Record<string, SectionGroup> | undefined;
 
   term: string;
+
+  termInfo: Record<string, string[]>;
 
   plannedCount: number | undefined;
 
@@ -116,6 +119,9 @@ export default class Course {
         }
       }
     );
+    this.termInfo = {
+      [getSemesterName(this.term)]: this.sections.flatMap((s) => s.instructors),
+    };
     this.prereqs = prereqs;
     this.coreqs = coreqs;
 
@@ -226,6 +232,7 @@ export default class Course {
     interface GpaCacheItem {
       d: CourseGpa;
       exp: string;
+      termInfo: Record<string, string[]>;
     }
 
     // Try to look in the cache for a cached course gpa item
@@ -243,6 +250,9 @@ export default class Course {
           // Use lexicographic comparison on date strings
           // (since they are ISO 8601)
           if (now < cacheItem.exp) {
+            if (cacheItem.termInfo) {
+              this.termInfo = cacheItem.termInfo;
+            }
             return cacheItem.d;
           }
         }
@@ -268,7 +278,11 @@ export default class Course {
         cache = JSON.parse(rawCache) as unknown as GpaCache;
       }
 
-      cache[this.id] = { d: courseGpa, exp: exp.toISOString() };
+      cache[this.id] = {
+        d: courseGpa,
+        exp: exp.toISOString(),
+        termInfo: this.termInfo,
+      };
       const rawUpdatedCache = JSON.stringify(cache);
       window.localStorage.setItem(GPA_CACHE_LOCAL_STORAGE_KEY, rawUpdatedCache);
     } catch (err) {
@@ -346,11 +360,13 @@ export default class Course {
           class_size_group: classSizeGroup,
           instructor_name: rawInstructorName,
           GPA: gpa,
+          Term: historicalTerm,
         } = historicalSectionData;
 
         if (typeof classSizeGroup !== 'string') return;
         if (typeof rawInstructorName !== 'string') return;
         if (typeof gpa !== 'number') return;
+        if (typeof historicalTerm !== 'string') return;
 
         // Map the class size group to an estimate
         // of the number of actual students.
@@ -402,6 +418,13 @@ export default class Course {
         instructorGpa.count += classSizeEstimate;
         instructorGpa.sum += gpa * classSizeEstimate;
         instructors.set(instructorName, instructorGpa);
+
+        const termKey = String(historicalTerm);
+        this.termInfo[termKey] ??= [];
+        const termInstructors = this.termInfo[termKey];
+        if (termInstructors && !termInstructors.includes(instructorName)) {
+          termInstructors.push(instructorName);
+        }
       });
 
       // Now, finally compute the actual weighted averages
@@ -451,6 +474,7 @@ interface CourseDetailsAPIResponse {
     link: string | unknown;
     class_size_group: string | unknown;
     GPA: number | unknown;
+    Term: string | unknown;
     A: number | unknown;
     B: number | unknown;
     C: number | unknown;

--- a/src/types.ts
+++ b/src/types.ts
@@ -234,6 +234,8 @@ export type PrerequisiteSet = [
  */
 export type CrawlerPrerequisites = PrerequisiteSet | [];
 
+export type CrawlerCorequisites = { id: string }[];
+
 // Caches type (imported as `CrawlerCaches`):
 // Copied from https://github.com/gt-scheduler/crawler/blob/master/src/types.ts
 
@@ -333,7 +335,9 @@ export type CrawlerCourse = [
   /**
    * Description pulled from Oscar
    */
-  description: string | null
+  description: string | null,
+  // ! Type had `undefined` explicitly added to ensure we check when accessing
+  corequisites: CrawlerCorequisites | undefined
 ];
 
 // TermData type (imported as `CrawlerTermData`):

--- a/src/utils/semesters.ts
+++ b/src/utils/semesters.ts
@@ -41,3 +41,40 @@ export function getSemesterName(term: string): string {
   })();
   return `${semester} ${year}`;
 }
+
+/**
+ * Converts a human-facing semester name back to a term string.
+ * Example: "Fall 2021" -> "202108"
+ */
+export function getTermFromSemesterName(semesterName: string): string | null {
+  const match = semesterName.match(/^(\w+)\s+(\d{4})$/);
+  if (!match) return null;
+
+  const semester = match[1];
+  const yearStr = match[2];
+
+  if (!semester || !yearStr) return null;
+
+  const year = Number(yearStr);
+  if (Number.isNaN(year)) return null;
+
+  let month: string;
+  switch (semester.toLowerCase()) {
+    case 'winter':
+      month = '01';
+      break;
+    case 'spring':
+      month = '02';
+      break;
+    case 'summer':
+      month = '05';
+      break;
+    case 'fall':
+      month = '08';
+      break;
+    default:
+      return null;
+  }
+
+  return `${year}${month}`;
+}

--- a/src/utils/semesters.ts
+++ b/src/utils/semesters.ts
@@ -18,7 +18,7 @@ export function isTerm(maybeTerm: string): boolean {
 /**
  * Gets the human-facing display name of a term/semester
  */
-export function getSemesterName(term: string): string {
+export function getSemesterName(term: string, yearFirst = false): string {
   if (!isTerm(term)) return 'Unknown';
 
   const year = term.substring(0, 4);
@@ -39,7 +39,7 @@ export function getSemesterName(term: string): string {
         return 'Unknown';
     }
   })();
-  return `${semester} ${year}`;
+  return yearFirst ? `${year} ${semester}` : `${semester} ${year}`;
 }
 
 /**

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -16,6 +16,7 @@ $theme-light-card-background: #e5e5e5;
 $theme-dark-card-background: #434343;
 $theme-light-foreground: $theme-dark-background;
 $theme-dark-foreground: $theme-light-background;
+$theme-dark-background-foreground: #3b3b3b;
 $color-background-light: #f8f9fa;
 $account-accent: #0c797d;
 $travel-time-blue: #589bd5;
@@ -46,6 +47,7 @@ $seat-info-light-label: #848173;
 $buttons-secondary-action: #676767;
 $buttons-secondary-action-dark: #2a2a2a;
 $buttons-secondary-gradient-dark: #323232;
+$buttons-navigation-hover: #424242;
 
 $information-blue: #57a0d5;
 


### PR DESCRIPTION
### Summary

This PR populates all the information needed for the short Course Info blob except for the rating reviews. This include Co-reqs (which are gotten with [a parallel crawler PR](https://github.com/gt-scheduler/crawler-v2/pull/53)), the description, and information about previous terms offered.

This is ready for both mobile and web (dark mode) but light mode designs are not yet available.

### How to Test
[PR Preview](https://gt-scheduler.github.io/website/pr-preview/pr-421/) (note coreqs will not work till crawler change pushed)

`yarn start`

(Run with parallel crawler)

<img width="1178" height="720" alt="image" src="https://github.com/user-attachments/assets/8a674c56-a38f-4ff0-bb75-8d15a64f649f" />

A more recent class (not all terms)
<img width="1226" height="653" alt="image" src="https://github.com/user-attachments/assets/56de4fcc-82b4-4301-960f-843daeddf24b" />

A class with coreqs
<img width="1172" height="645" alt="image" src="https://github.com/user-attachments/assets/eedd5f3b-003d-42a7-ae7e-5fd24c3fe9b7" />


Mobile
<img width="382" height="772" alt="image" src="https://github.com/user-attachments/assets/87f57f4e-26a4-4085-ba32-f0536ee95c03" />

<img width="421" height="775" alt="image" src="https://github.com/user-attachments/assets/8466ea7e-b96f-4536-86b7-c4174eb87427" />
