### PR TITLE
Add light mode designs

### DIFF
--- a/src/components/Card/stylesheet.scss
+++ b/src/components/Card/stylesheet.scss
@@ -3,7 +3,7 @@
 .CardContainer {
   display: flex;
   flex-direction: column;
-  @include dark(background-color, $theme-dark-background-foreground);
+  @include dark(background-color, $card-dark-background);
   @include light(background-color, $card-light-background);
   border-left: 8px solid $theme-dark-background-foreground;
   border-radius: 5px;

--- a/src/components/Card/stylesheet.scss
+++ b/src/components/Card/stylesheet.scss
@@ -3,7 +3,8 @@
 .CardContainer {
   display: flex;
   flex-direction: column;
-  background-color: $theme-dark-background-foreground;
+  @include dark(background-color, $theme-dark-background-foreground);
+  @include light(background-color, $card-light-background);
   border-left: 8px solid $theme-dark-background-foreground;
   border-radius: 5px;
   padding: 20px;

--- a/src/components/Course/index.tsx
+++ b/src/components/Course/index.tsx
@@ -3,7 +3,6 @@ import {
   faAngleDown,
   faAngleUp,
   faShareAlt,
-  faCircleInfo,
   faPalette,
   faPlus,
   faTrash,

--- a/src/components/Course/index.tsx
+++ b/src/components/Course/index.tsx
@@ -177,14 +177,6 @@ export default function Course({
                 },
                 prereqAction,
                 {
-                  icon: faCircleInfo,
-                  onClick: (): void => {
-                    console.log('view course info');
-                  },
-                  tooltip: 'View Course Info',
-                  id: `${course.id}-info`,
-                },
-                {
                   icon: faPalette,
                   onClick: (): void => {
                     setPaletteShown(!paletteShown);

--- a/src/components/Course/index.tsx
+++ b/src/components/Course/index.tsx
@@ -3,6 +3,7 @@ import {
   faAngleDown,
   faAngleUp,
   faShareAlt,
+  faCircleInfo,
   faPalette,
   faPlus,
   faTrash,
@@ -175,6 +176,14 @@ export default function Course({
                   onClick: (): void => prereqControl(false, !expanded),
                 },
                 prereqAction,
+                {
+                  icon: faCircleInfo,
+                  onClick: (): void => {
+                    console.log('view course info');
+                  },
+                  tooltip: 'View Course Info',
+                  id: `${course.id}-info`,
+                },
                 {
                   icon: faPalette,
                   onClick: (): void => {

--- a/src/components/CourseInfo/stylesheet.scss
+++ b/src/components/CourseInfo/stylesheet.scss
@@ -70,7 +70,6 @@
 
       .course-terms-tab-bar {
         @include dark(background-color, $buttons-navigation-hover);
-        @include light(background-color, $card-light-background);
       }
 
       .course-terms-tab-bar.enable-select {

--- a/src/components/CourseInfo/stylesheet.scss
+++ b/src/components/CourseInfo/stylesheet.scss
@@ -69,11 +69,11 @@
       gap: 20px;
 
       .course-terms-tab-bar {
-        background-color: $buttons-navigation-hover;
+        @include dark(background-color, $buttons-navigation-hover);
+        @include light(background-color, $card-light-background);
       }
 
       .course-terms-tab-bar.enable-select {
-        background-color: $theme-dark-background-foreground;
         padding: 2px;
         .tab {
           border-radius: 8px;

--- a/src/components/MetricsCard/stylesheet.scss
+++ b/src/components/MetricsCard/stylesheet.scss
@@ -43,7 +43,8 @@
       }
 
       .metric-label {
-        color: $modal-foreground-color-dark;
+        @include dark(color, $table-header-dark);
+        @include light(color, $table-header-light);
       }
     }
   }

--- a/src/components/ProfessorInfoCard/stylesheet.scss
+++ b/src/components/ProfessorInfoCard/stylesheet.scss
@@ -7,8 +7,8 @@
   flex-direction: column;
   gap: 20px;
 
-  @include dark(background, $theme-dark-background-foreground);
-  @include light(background, $theme-light-card-background);
+  @include dark(background-color, $card-dark-background);
+  @include light(background-color, $card-light-background);
 
   .professor-header {
     padding: 0px;
@@ -61,7 +61,8 @@
     .sections-header {
       padding: 0px;
       padding-left: 0px;
-      color: $table-header;
+      @include dark(color, $table-header-dark);
+      @include light(color, $table-header-light);
       > .left-group,
       > .right-group {
         display: contents;

--- a/src/components/ProfessorInfoCard/stylesheet.scss
+++ b/src/components/ProfessorInfoCard/stylesheet.scss
@@ -121,18 +121,28 @@
 
 .fade-right {
   right: 0;
-  background: linear-gradient(
+  @include dark (background, linear-gradient(
     270deg,
-    $theme-dark-background-foreground 0%,
+    $card-dark-background 0%,
     rgba(59, 59, 59, 0) 100%
-  );
+  ));
+  @include light (background, linear-gradient(
+    270deg,
+    $card-light-background 0%,
+    rgba(255, 255, 255, 0) 100%
+  ));
 }
 
 .fade-left {
   left: 0;
-  background: linear-gradient(
+  @include dark (background, linear-gradient(
     90deg,
-    $theme-dark-background-foreground 0%,
+    $card-dark-background 0%,
     rgba(59, 59, 59, 0) 100%
-  );
+  ));
+  @include light (background, linear-gradient(
+    90deg,
+    $card-light-background 0%,
+    rgba(255, 255, 255, 0) 100%
+  ));
 }

--- a/src/components/ProfessorInfoCard/stylesheet.scss
+++ b/src/components/ProfessorInfoCard/stylesheet.scss
@@ -126,11 +126,6 @@
     $card-dark-background 0%,
     rgba(59, 59, 59, 0) 100%
   ));
-  @include light (background, linear-gradient(
-    270deg,
-    $card-light-background 0%,
-    rgba(255, 255, 255, 0) 100%
-  ));
 }
 
 .fade-left {
@@ -139,10 +134,5 @@
     90deg,
     $card-dark-background 0%,
     rgba(59, 59, 59, 0) 100%
-  ));
-  @include light (background, linear-gradient(
-    90deg,
-    $card-light-background 0%,
-    rgba(255, 255, 255, 0) 100%
   ));
 }

--- a/src/components/TabBar/stylesheet.scss
+++ b/src/components/TabBar/stylesheet.scss
@@ -18,6 +18,8 @@
   &::-webkit-scrollbar {
     display: none;
   }
+  overflow-x: auto; // Better than 'scroll' as it hides bars when not needed
+  overflow-y: hidden;
 
   .tab {
     min-width: 128px;

--- a/src/components/TabBar/stylesheet.scss
+++ b/src/components/TabBar/stylesheet.scss
@@ -66,20 +66,20 @@
 
 .fade-right {
   right: 0;
-  background: linear-gradient(
+  @include dark(background, linear-gradient(
     to right,
     rgba($buttons-secondary-action-dark, 0),
     rgba($buttons-secondary-action-dark, 1)
-  );
+  ));
   border-radius: 0 10px 10px 0;
 }
 
 .fade-left {
   left: 0;
-  background: linear-gradient(
+  @include dark(background, linear-gradient(
     to left,
     rgba($buttons-secondary-action-dark, 0),
     rgba($buttons-secondary-action-dark, 1)
-  );
+  )); 
   border-radius: 10px 0 0 10px;
 }

--- a/src/components/TabBar/stylesheet.scss
+++ b/src/components/TabBar/stylesheet.scss
@@ -8,7 +8,8 @@
 .TabBar {
   display: flex;
   align-items: center;
-  background-color: $buttons-secondary-action-dark;
+  @include dark(background-color, $buttons-secondary-action-dark);
+  @include light(background-color, $buttons-secondary-action-light);
   border-radius: 10px;
   padding: 4px;
   scroll-behavior: smooth;
@@ -32,9 +33,9 @@
     gap: 8px;
 
     &.active {
-      background-color: rgba($color-neutral, 0.3);
+      @include dark(background-color, rgba($color-neutral, 0.3));
+      @include light(background-color, $theme-light-background);
       @include dark(color, $theme-light-background);
-      @include light(color, $theme-dark-background);
       font-weight: bold;
     }
   }
@@ -44,7 +45,7 @@
     overflow-x: visible;
     justify-content: flex-start;
     .tab {
-      color: $theme-light-background;
+      @include dark(color, $theme-light-background);
       cursor: default;
       opacity: 1;
     }

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -46,11 +46,16 @@ $seat-info-light-label: #848173;
 
 $buttons-secondary-action: #676767;
 $buttons-secondary-action-dark: #2a2a2a;
+$buttons-secondary-action-light: rgba($theme-dark-background, 0.10);
 $buttons-secondary-gradient-dark: #323232;
 $buttons-navigation-hover: #424242;
 
+$card-light-background: rgba(51, 51, 51, 0.05);
+$card-dark-background: $theme-dark-background-foreground;
+
 $information-blue: #57a0d5;
-$table-header: #adadad;
+$table-header-dark: #adadad;
+$table-header-light: rgba(51, 51, 51, 0.60);
 $table-border: #505050;
 
 @mixin card {


### PR DESCRIPTION
### Summary

Resolves #426 

Adds light mode designs for View Mode tab, Course Details, Section Details

### How to Test
View Mode tab:
<img width="328" height="44" alt="Screenshot 2026-01-29 at 2 52 03 PM" src="https://github.com/user-attachments/assets/274ef638-6ea3-4ef1-8096-c045f2a1355f" />

Course Details:
<img width="1703" height="862" alt="Screenshot 2026-01-29 at 2 52 21 PM" src="https://github.com/user-attachments/assets/4c4544c5-4ba8-4433-98db-aa06494cd1e5" />

Section Details:
<img width="1703" height="863" alt="Screenshot 2026-01-29 at 2 52 42 PM" src="https://github.com/user-attachments/assets/7b396715-8d2e-45d7-acf0-211d3c4dca27" />
<img width="1701" height="861" alt="Screenshot 2026-01-29 at 2 53 29 PM" src="https://github.com/user-attachments/assets/aca1bdec-5a07-4537-a3e2-031bfb2a2e1b" />

Gradient:
<img width="593" height="44" alt="Screenshot 2026-01-29 at 2 53 01 PM" src="https://github.com/user-attachments/assets/4eb60372-3968-4c20-b6df-9326c624b689" />
<img width="588" height="311" alt="Screenshot 2026-01-29 at 2 53 12 PM" src="https://github.com/user-attachments/assets/247657eb-610c-47d6-aff8-4b2222e5d5bc" />

Mobile:
<img width="362" height="796" alt="Screenshot 2026-01-29 at 2 53 54 PM" src="https://github.com/user-attachments/assets/4d379cb5-2783-47e6-936e-2b734d64b81d" />
<img width="354" height="785" alt="Screenshot 2026-01-29 at 2 54 09 PM" src="https://github.com/user-attachments/assets/12848313-ed80-4c45-8690-cb30a6cc3715" />
<img width="361" height="790" alt="Screenshot 2026-01-29 at 2 54 19 PM" src="https://github.com/user-attachments/assets/0869c445-25c9-43fb-be10-d075d029d40d" />

Previous Semesters:
<img width="1706" height="860" alt="Screenshot 2026-01-29 at 2 55 19 PM" src="https://github.com/user-attachments/assets/6043bb78-fb55-4325-8a8a-d4f58b06a8a6" />
<img width="1081" height="866" alt="Screenshot 2026-01-29 at 2 55 45 PM" src="https://github.com/user-attachments/assets/48597f39-6576-49a9-9049-79f038350b79" />

Dark Mode unchanged:
<img width="1073" height="862" alt="Screenshot 2026-01-29 at 2 56 07 PM" src="https://github.com/user-attachments/assets/47abf82c-d58e-4cbd-b77c-7161e6236502" />
<img width="1079" height="865" alt="Screenshot 2026-01-29 at 2 56 25 PM" src="https://github.com/user-attachments/assets/d11f9a4a-6e7e-4d40-9de4-dd44b874658e" />

also fixed small bug where semester tab bar was not scrollable