### PR TITLE
Populate course and prof metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "swr": "^2.3.6",
     "tslib": "2.3.0",
     "use-local-storage-state": "^18.1.2",
-    "uuid": "^9.0.0"
+    "uuid": "^9.0.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@bitwarden/cli": "^2022.8.0",

--- a/src/components/CourseInfo/index.tsx
+++ b/src/components/CourseInfo/index.tsx
@@ -2,7 +2,8 @@ import React, { useContext, useEffect, useMemo, useState } from 'react';
 
 import { ScheduleContext } from '../../contexts';
 import { serializePrereqs } from '../../utils/misc';
-import { CrawlerPrerequisites } from '../../types';
+import { CourseGpa, CrawlerPrerequisites } from '../../types';
+import { slugifyProfessor } from '../../data/beans/Course';
 import MetricsCard from '../MetricsCard';
 import TabBar from '../TabBar';
 import { ErrorWithFields, softError } from '../../log';
@@ -26,19 +27,22 @@ export default function CourseInfo({
   const course = useMemo(() => oscar.findCourse(courseId), [oscar, courseId]);
 
   const [isLoaded, setIsLoaded] = useState(false);
+  const [isProfessorRatingsLoaded, setIsProfessorRatingsLoaded] =
+    useState(false);
   const [selectedTermKey, setSelectedTermKey] = useState<string | null>(null);
+  const [gpaMap, setGpaMap] = useState<CourseGpa | null>(null);
 
   useEffect(() => {
     if (course) {
-      course
-        .fetchGpa()
-        .then(() => {
+      Promise.all([course.fetchGpa(), course.fetchRatings()])
+        .then(([gpaData]) => {
+          setGpaMap(gpaData);
           setIsLoaded(true);
         })
         .catch((err) => {
           softError(
             new ErrorWithFields({
-              message: 'error fetching course GPA',
+              message: 'error fetching course data',
               source: err,
               fields: {
                 courseId,
@@ -96,13 +100,31 @@ export default function CourseInfo({
 
   useEffect(() => {
     if (enableTermSelect) {
+      if (course) {
+        Promise.all([course.fetchProfessorRatings(course.term)])
+          .then(() => {
+            setIsProfessorRatingsLoaded(true);
+          })
+          .catch((err) => {
+            softError(
+              new ErrorWithFields({
+                message: 'error fetching professor ratings',
+                source: err,
+                fields: {
+                  courseId,
+                  term: course.term,
+                },
+              })
+            );
+          });
+      }
       if (offeredTerms.length > 0 && !selectedTermKey) {
         setSelectedTermKey(
           offeredTerms && offeredTerms[0] ? offeredTerms[0] : null
         );
       }
     }
-  }, [enableTermSelect, offeredTerms, selectedTermKey]);
+  }, [enableTermSelect, course, offeredTerms, selectedTermKey]);
 
   const instructorsForSelectedTerm = useMemo(() => {
     if (!course || !selectedTermKey) return [];
@@ -111,29 +133,108 @@ export default function CourseInfo({
     return Array.from(new Set(rawInstructors));
   }, [course, selectedTermKey]);
 
+  const formatValue = (val: number, decimals: number): string =>
+    Number.isInteger(val) ? val.toString() : val.toFixed(decimals);
+
+  const metrics = useMemo(() => {
+    if (!isLoaded || !course?.ratings) {
+      return [
+        { label: 'Overall Rating', value: '—' },
+        {
+          label: 'Course GPA',
+          value:
+            gpaMap === null
+              ? 'Loading...'
+              : gpaMap.averageGpa
+              ? formatValue(gpaMap.averageGpa, 2)
+              : '-',
+        },
+        { label: 'Level of Difficulty', value: '—' },
+        { label: 'Workload', value: '—', unit: 'hrs/week' },
+      ];
+    }
+
+    return [
+      {
+        label: 'Overall Rating',
+        value: `${formatValue(course.ratings.averageRating, 2)}/5`,
+      },
+      {
+        label: 'Course GPA',
+        value:
+          gpaMap === null
+            ? 'Loading...'
+            : gpaMap.averageGpa
+            ? formatValue(gpaMap.averageGpa, 2)
+            : '-',
+      },
+      {
+        label: 'Level of Difficulty',
+        value: `${formatValue(course.ratings.averageDifficulty, 1)}/5`,
+      },
+      {
+        label: 'Workload',
+        value: formatValue(course.ratings.averageWorkload, 1),
+        unit: 'hrs/week',
+      },
+    ];
+  }, [isLoaded, course?.ratings, gpaMap]);
+
+  // This function generates metrics for a specific professor
+  const getProfessorMetrics = (
+    professorName: string
+  ): { label: string; value: string; unit?: string }[] => {
+    const profGpa = gpaMap?.[professorName];
+    const slugifiedName = slugifyProfessor(professorName);
+    if (
+      !isProfessorRatingsLoaded ||
+      !course?.professorRatings ||
+      !course.professorRatings[slugifiedName]
+    ) {
+      return [
+        { label: 'Overall Rating', value: '—' },
+        {
+          label: 'Course GPA',
+          value: profGpa ? formatValue(profGpa, 2) : '—',
+        },
+        { label: 'Level of Difficulty', value: '—' },
+        { label: 'Workload', value: '—', unit: 'hrs/week' },
+      ];
+    }
+
+    return [
+      {
+        label: 'Overall Rating',
+        value: `${formatValue(
+          course?.professorRatings[slugifiedName]!.averageRating,
+          2
+        )}/5`,
+      },
+      {
+        label: 'Course GPA',
+        value: profGpa ? formatValue(profGpa, 2) : '-',
+      },
+      {
+        label: 'Level of Difficulty',
+        value: `${formatValue(
+          course?.professorRatings[slugifiedName]!.averageDifficulty,
+          1
+        )}/5`,
+      },
+      {
+        label: 'Workload',
+        value: formatValue(
+          course?.professorRatings[slugifiedName]!.averageWorkload,
+          1
+        ),
+        unit: 'hrs/week',
+      },
+    ];
+  };
+
   if (!course) {
     return <div />;
   }
-
-  const metrics = [
-    {
-      label: 'Overall Rating',
-      value: '3.91/5',
-    },
-    {
-      label: 'Course GPA',
-      value: '3.91',
-    },
-    {
-      label: 'Level of Difficulty',
-      value: '3.4/5',
-    },
-    {
-      label: 'Workload',
-      value: '14.5',
-      unit: 'hrs/week',
-    },
-  ];
 
   return (
     <div className="course-info-container">
@@ -202,7 +303,7 @@ export default function CourseInfo({
                   <ProfessorInfoCard
                     key={instructorName}
                     professorName={instructorName}
-                    professorMetrics={metrics}
+                    professorMetrics={getProfessorMetrics(instructorName)}
                     course={course}
                     displaySectionInfo={selectedTermKey === term}
                   />

--- a/src/components/CourseInfo/index.tsx
+++ b/src/components/CourseInfo/index.tsx
@@ -35,8 +35,9 @@ export default function CourseInfo({
 
   useEffect(() => {
     if (course) {
-      Promise.all([course.fetchGpa()])
-        .then(([gpaData]) => {
+      course
+        .fetchGpa()
+        .then((gpaData) => {
           setGpaMap(gpaData);
           setIsLoaded(true);
         })
@@ -52,7 +53,8 @@ export default function CourseInfo({
             })
           );
         });
-      Promise.all([course.fetchRatings()])
+      course
+        .fetchRatings()
         .then(() => {
           setIsRatingsLoaded(true);
         })
@@ -127,7 +129,8 @@ export default function CourseInfo({
 
   useEffect(() => {
     if (selectedTermKey && course) {
-      Promise.all([course.fetchProfessorRatings(course.term)])
+      course
+        .fetchProfessorRatings(selectedTermKey)
         .then(() => {
           setIsProfessorRatingsLoaded(true);
         })

--- a/src/components/CourseInfo/index.tsx
+++ b/src/components/CourseInfo/index.tsx
@@ -32,16 +32,33 @@ export default function CourseInfo({
 
   useEffect(() => {
     if (course) {
-      Promise.all([course.fetchGpa(), course.fetchRatings()])
-        .then(([gpaData]) => {
+      course
+        .fetchGpa()
+        .then((gpaData) => {
           setGpaMap(gpaData);
           setIsLoaded(true);
+        })
+        .catch((err) => {
+          softError(
+            new ErrorWithFields({
+              message: 'error fetching course gpa',
+              source: err,
+              fields: {
+                courseId,
+                term: course.term,
+              },
+            })
+          );
+        });
+      course
+        .fetchRatings()
+        .then(() => {
           setIsRatingsLoaded(true);
         })
         .catch((err) => {
           softError(
             new ErrorWithFields({
-              message: 'error fetching course data',
+              message: 'error fetching course ratings',
               source: err,
               fields: {
                 courseId,

--- a/src/components/CourseInfo/index.tsx
+++ b/src/components/CourseInfo/index.tsx
@@ -2,8 +2,8 @@ import React, { useContext, useEffect, useMemo, useState } from 'react';
 
 import { ScheduleContext } from '../../contexts';
 import { serializePrereqs } from '../../utils/misc';
-import { CourseGpa, CrawlerPrerequisites } from '../../types';
 import { slugifyProfessor } from '../../data/beans/Course';
+import { CourseGpa, CrawlerPrerequisites } from '../../types';
 import MetricsCard from '../MetricsCard';
 import TabBar from '../TabBar';
 import { ErrorWithFields, softError } from '../../log';
@@ -27,6 +27,7 @@ export default function CourseInfo({
   const course = useMemo(() => oscar.findCourse(courseId), [oscar, courseId]);
 
   const [isLoaded, setIsLoaded] = useState(false);
+  const [isRatingsLoaded, setIsRatingsLoaded] = useState(false);
   const [isProfessorRatingsLoaded, setIsProfessorRatingsLoaded] =
     useState(false);
   const [selectedTermKey, setSelectedTermKey] = useState<string | null>(null);
@@ -34,7 +35,7 @@ export default function CourseInfo({
 
   useEffect(() => {
     if (course) {
-      Promise.all([course.fetchGpa(), course.fetchRatings()])
+      Promise.all([course.fetchGpa()])
         .then(([gpaData]) => {
           setGpaMap(gpaData);
           setIsLoaded(true);
@@ -42,7 +43,23 @@ export default function CourseInfo({
         .catch((err) => {
           softError(
             new ErrorWithFields({
-              message: 'error fetching course data',
+              message: 'error fetching course gpa',
+              source: err,
+              fields: {
+                courseId,
+                term: course.term,
+              },
+            })
+          );
+        });
+      Promise.all([course.fetchRatings()])
+        .then(() => {
+          setIsRatingsLoaded(true);
+        })
+        .catch((err) => {
+          softError(
+            new ErrorWithFields({
+              message: 'error fetching course ratings',
               source: err,
               fields: {
                 courseId,
@@ -100,24 +117,6 @@ export default function CourseInfo({
 
   useEffect(() => {
     if (enableTermSelect) {
-      if (course) {
-        Promise.all([course.fetchProfessorRatings(course.term)])
-          .then(() => {
-            setIsProfessorRatingsLoaded(true);
-          })
-          .catch((err) => {
-            softError(
-              new ErrorWithFields({
-                message: 'error fetching professor ratings',
-                source: err,
-                fields: {
-                  courseId,
-                  term: course.term,
-                },
-              })
-            );
-          });
-      }
       if (offeredTerms.length > 0 && !selectedTermKey) {
         setSelectedTermKey(
           offeredTerms && offeredTerms[0] ? offeredTerms[0] : null
@@ -126,38 +125,39 @@ export default function CourseInfo({
     }
   }, [enableTermSelect, course, offeredTerms, selectedTermKey]);
 
-  const instructorsForSelectedTerm = useMemo(() => {
-    if (!course || !selectedTermKey) return [];
-
-    const rawInstructors = course.termInfo?.[selectedTermKey] ?? [];
-    return Array.from(new Set(rawInstructors));
-  }, [course, selectedTermKey]);
+  useEffect(() => {
+    if (selectedTermKey && course) {
+      Promise.all([course.fetchProfessorRatings(course.term)])
+        .then(() => {
+          setIsProfessorRatingsLoaded(true);
+        })
+        .catch((err) => {
+          softError(
+            new ErrorWithFields({
+              message: 'error fetching professor ratings',
+              source: err,
+              fields: {
+                courseId,
+                term: course.term,
+              },
+            })
+          );
+        });
+    }
+  }, [selectedTermKey, course]);
 
   const formatValue = (val: number, decimals: number): string =>
     Number.isInteger(val) ? val.toString() : val.toFixed(decimals);
 
   const metrics = useMemo(() => {
-    if (!isLoaded || !course?.ratings) {
-      return [
-        { label: 'Overall Rating', value: '—' },
-        {
-          label: 'Course GPA',
-          value:
-            gpaMap === null
-              ? 'Loading...'
-              : gpaMap.averageGpa
-              ? formatValue(gpaMap.averageGpa, 2)
-              : '-',
-        },
-        { label: 'Level of Difficulty', value: '—' },
-        { label: 'Workload', value: '—', unit: 'hrs/week' },
-      ];
-    }
-
     return [
       {
         label: 'Overall Rating',
-        value: `${formatValue(course.ratings.averageRating, 2)}/5`,
+        value: !isRatingsLoaded
+          ? 'Loading'
+          : course?.ratings
+          ? `${formatValue(course.ratings.averageRating, 2)}/5`
+          : '—',
       },
       {
         label: 'Course GPA',
@@ -170,67 +170,91 @@ export default function CourseInfo({
       },
       {
         label: 'Level of Difficulty',
-        value: `${formatValue(course.ratings.averageDifficulty, 1)}/5`,
+        value: !isRatingsLoaded
+          ? 'Loading'
+          : course?.ratings
+          ? `${formatValue(course.ratings.averageDifficulty, 1)}/5`
+          : '—',
       },
       {
         label: 'Workload',
-        value: formatValue(course.ratings.averageWorkload, 1),
+        value: !isRatingsLoaded
+          ? 'Loading'
+          : course?.ratings
+          ? formatValue(course.ratings.averageWorkload, 1)
+          : '—',
         unit: 'hrs/week',
       },
     ];
-  }, [isLoaded, course?.ratings, gpaMap]);
+  }, [isLoaded, isRatingsLoaded, course?.ratings, gpaMap]);
 
-  // This function generates metrics for a specific professor
-  const getProfessorMetrics = (
-    professorName: string
-  ): { label: string; value: string; unit?: string }[] => {
-    const profGpa = gpaMap?.[professorName];
-    const slugifiedName = slugifyProfessor(professorName);
-    if (
-      !isProfessorRatingsLoaded ||
-      !course?.professorRatings ||
-      !course.professorRatings[slugifiedName]
-    ) {
-      return [
-        { label: 'Overall Rating', value: '—' },
-        {
-          label: 'Course GPA',
-          value: profGpa ? formatValue(profGpa, 2) : '—',
-        },
-        { label: 'Level of Difficulty', value: '—' },
-        { label: 'Workload', value: '—', unit: 'hrs/week' },
-      ];
-    }
+  const instructorsForSelectedTerm = useMemo(() => {
+    if (!course || !selectedTermKey) return [];
 
-    return [
-      {
-        label: 'Overall Rating',
-        value: `${formatValue(
-          course?.professorRatings[slugifiedName]!.averageRating,
-          2
-        )}/5`,
-      },
-      {
-        label: 'Course GPA',
-        value: profGpa ? formatValue(profGpa, 2) : '-',
-      },
-      {
-        label: 'Level of Difficulty',
-        value: `${formatValue(
-          course?.professorRatings[slugifiedName]!.averageDifficulty,
-          1
-        )}/5`,
-      },
-      {
-        label: 'Workload',
-        value: formatValue(
-          course?.professorRatings[slugifiedName]!.averageWorkload,
-          1
-        ),
-        unit: 'hrs/week',
-      },
-    ];
-  };
+    const rawInstructors = course.termInfo?.[selectedTermKey] ?? [];
+    return Array.from(new Set(rawInstructors));
+  }, [course, selectedTermKey]);
+
+  // Memoize professor metrics so they update when ratings load
+  const professorMetricsMap = useMemo(() => {
+    const metricsMap: Record<
+      string,
+      { label: string; value: string; unit?: string }[]
+    > = {};
+
+    instructorsForSelectedTerm.forEach((professorName) => {
+      const profGpa = gpaMap?.[professorName];
+      const slugifiedName = slugifyProfessor(professorName);
+      console.log(isProfessorRatingsLoaded, course?.professorRatings);
+
+      if (!isProfessorRatingsLoaded || !course?.professorRatings) {
+        metricsMap[slugifiedName] = [
+          { label: 'Overall Rating', value: '—' },
+          {
+            label: 'Course GPA',
+            value: profGpa ? formatValue(profGpa, 2) : '—',
+          },
+          { label: 'Level of Difficulty', value: '—' },
+          { label: 'Workload', value: '—', unit: 'hrs/week' },
+        ];
+      } else {
+        const profRating = course.professorRatings[slugifiedName];
+
+        metricsMap[slugifiedName] = [
+          {
+            label: 'Overall Rating',
+            value: profRating
+              ? `${formatValue(profRating.averageRating, 2)}/5`
+              : '—',
+          },
+          {
+            label: 'Course GPA',
+            value: profGpa ? formatValue(profGpa, 2) : '—',
+          },
+          {
+            label: 'Level of Difficulty',
+            value: profRating
+              ? `${formatValue(profRating.averageDifficulty, 1)}/5`
+              : '—',
+          },
+          {
+            label: 'Workload',
+            value: profRating
+              ? formatValue(profRating.averageWorkload, 1)
+              : '—',
+            unit: 'hrs/week',
+          },
+        ];
+      }
+    });
+
+    return metricsMap;
+  }, [
+    instructorsForSelectedTerm,
+    isProfessorRatingsLoaded,
+    course?.professorRatings,
+    gpaMap,
+  ]);
 
   if (!course) {
     return <div />;
@@ -303,7 +327,14 @@ export default function CourseInfo({
                   <ProfessorInfoCard
                     key={instructorName}
                     professorName={instructorName}
-                    professorMetrics={getProfessorMetrics(instructorName)}
+                    professorMetrics={
+                      professorMetricsMap[slugifyProfessor(instructorName)] ?? [
+                        { label: 'Overall Rating', value: '—' },
+                        { label: 'Course GPA', value: '—' },
+                        { label: 'Level of Difficulty', value: '—' },
+                        { label: 'Workload', value: '—', unit: 'hrs/week' },
+                      ]
+                    }
                     course={course}
                     displaySectionInfo={selectedTermKey === term}
                   />

--- a/src/components/CourseInfo/index.tsx
+++ b/src/components/CourseInfo/index.tsx
@@ -144,7 +144,7 @@ export default function CourseInfo({
           );
         });
     }
-  }, [selectedTermKey, course]);
+  }, [selectedTermKey, course, courseId]);
 
   const formatValue = (val: number, decimals: number): string =>
     Number.isInteger(val) ? val.toString() : val.toFixed(decimals);
@@ -186,7 +186,7 @@ export default function CourseInfo({
         unit: 'hrs/week',
       },
     ];
-  }, [isLoaded, isRatingsLoaded, course?.ratings, gpaMap]);
+  }, [isRatingsLoaded, course?.ratings, gpaMap]);
 
   const instructorsForSelectedTerm = useMemo(() => {
     if (!course || !selectedTermKey) return [];
@@ -195,7 +195,6 @@ export default function CourseInfo({
     return Array.from(new Set(rawInstructors));
   }, [course, selectedTermKey]);
 
-  // Memoize professor metrics so they update when ratings load
   const professorMetricsMap = useMemo(() => {
     const metricsMap: Record<
       string,
@@ -205,7 +204,6 @@ export default function CourseInfo({
     instructorsForSelectedTerm.forEach((professorName) => {
       const profGpa = gpaMap?.[professorName];
       const slugifiedName = slugifyProfessor(professorName);
-      console.log(isProfessorRatingsLoaded, course?.professorRatings);
 
       if (!isProfessorRatingsLoaded || !course?.professorRatings) {
         metricsMap[slugifiedName] = [

--- a/src/components/CourseInfo/index.tsx
+++ b/src/components/CourseInfo/index.tsx
@@ -1,8 +1,7 @@
 import React, { useContext, useEffect, useMemo, useState } from 'react';
 
 import { ScheduleContext } from '../../contexts';
-import { serializePrereqs } from '../../utils/misc';
-import { slugifyProfessor } from '../../data/beans/Course';
+import { serializePrereqs, slugify } from '../../utils/misc';
 import { CourseGpa, CrawlerPrerequisites } from '../../types';
 import MetricsCard from '../MetricsCard';
 import TabBar from '../TabBar';
@@ -16,8 +15,6 @@ export type CourseInfoProps = {
   courseId: string;
   enableTermSelect?: boolean;
 };
-
-// Need to create course info short and course info long
 
 export default function CourseInfo({
   courseId,
@@ -35,33 +32,16 @@ export default function CourseInfo({
 
   useEffect(() => {
     if (course) {
-      course
-        .fetchGpa()
-        .then((gpaData) => {
+      Promise.all([course.fetchGpa(), course.fetchRatings()])
+        .then(([gpaData]) => {
           setGpaMap(gpaData);
           setIsLoaded(true);
-        })
-        .catch((err) => {
-          softError(
-            new ErrorWithFields({
-              message: 'error fetching course gpa',
-              source: err,
-              fields: {
-                courseId,
-                term: course.term,
-              },
-            })
-          );
-        });
-      course
-        .fetchRatings()
-        .then(() => {
           setIsRatingsLoaded(true);
         })
         .catch((err) => {
           softError(
             new ErrorWithFields({
-              message: 'error fetching course ratings',
+              message: 'error fetching course data',
               source: err,
               fields: {
                 courseId,
@@ -149,43 +129,38 @@ export default function CourseInfo({
     }
   }, [selectedTermKey, course, courseId]);
 
-  const formatValue = (val: number, decimals: number): string =>
-    Number.isInteger(val) ? val.toString() : val.toFixed(decimals);
-
   const metrics = useMemo(() => {
+    const courseRatings = course?.ratings;
+    const courseGpa = gpaMap?.averageGpa;
+
     return [
       {
         label: 'Overall Rating',
         value: !isRatingsLoaded
-          ? 'Loading'
-          : course?.ratings
-          ? `${formatValue(course.ratings.averageRating, 2)}/5`
-          : '—',
+          ? 'Loading...'
+          : courseRatings
+          ? `${courseRatings.averageRating.toFixed(2)}/5`
+          : null,
       },
       {
         label: 'Course GPA',
-        value:
-          gpaMap === null
-            ? 'Loading...'
-            : gpaMap.averageGpa
-            ? formatValue(gpaMap.averageGpa, 2)
-            : '-',
+        value: gpaMap === null ? 'Loading...' : courseGpa?.toFixed(2) ?? null,
       },
       {
         label: 'Level of Difficulty',
         value: !isRatingsLoaded
-          ? 'Loading'
-          : course?.ratings
-          ? `${formatValue(course.ratings.averageDifficulty, 1)}/5`
-          : '—',
+          ? 'Loading...'
+          : courseRatings
+          ? `${courseRatings.averageDifficulty.toFixed(1)}/5`
+          : null,
       },
       {
         label: 'Workload',
         value: !isRatingsLoaded
-          ? 'Loading'
-          : course?.ratings
-          ? formatValue(course.ratings.averageWorkload, 1)
-          : '—',
+          ? 'Loading...'
+          : courseRatings
+          ? courseRatings.averageWorkload.toFixed(1)
+          : null,
         unit: 'hrs/week',
       },
     ];
@@ -197,65 +172,6 @@ export default function CourseInfo({
     const rawInstructors = course.termInfo?.[selectedTermKey] ?? [];
     return Array.from(new Set(rawInstructors));
   }, [course, selectedTermKey]);
-
-  const professorMetricsMap = useMemo(() => {
-    const metricsMap: Record<
-      string,
-      { label: string; value: string; unit?: string }[]
-    > = {};
-
-    instructorsForSelectedTerm.forEach((professorName) => {
-      const profGpa = gpaMap?.[professorName];
-      const slugifiedName = slugifyProfessor(professorName);
-
-      if (!isProfessorRatingsLoaded || !course?.professorRatings) {
-        metricsMap[slugifiedName] = [
-          { label: 'Overall Rating', value: '—' },
-          {
-            label: 'Course GPA',
-            value: profGpa ? formatValue(profGpa, 2) : '—',
-          },
-          { label: 'Level of Difficulty', value: '—' },
-          { label: 'Workload', value: '—', unit: 'hrs/week' },
-        ];
-      } else {
-        const profRating = course.professorRatings[slugifiedName];
-
-        metricsMap[slugifiedName] = [
-          {
-            label: 'Overall Rating',
-            value: profRating
-              ? `${formatValue(profRating.averageRating, 2)}/5`
-              : '—',
-          },
-          {
-            label: 'Course GPA',
-            value: profGpa ? formatValue(profGpa, 2) : '—',
-          },
-          {
-            label: 'Level of Difficulty',
-            value: profRating
-              ? `${formatValue(profRating.averageDifficulty, 1)}/5`
-              : '—',
-          },
-          {
-            label: 'Workload',
-            value: profRating
-              ? formatValue(profRating.averageWorkload, 1)
-              : '—',
-            unit: 'hrs/week',
-          },
-        ];
-      }
-    });
-
-    return metricsMap;
-  }, [
-    instructorsForSelectedTerm,
-    isProfessorRatingsLoaded,
-    course?.professorRatings,
-    gpaMap,
-  ]);
 
   if (!course) {
     return <div />;
@@ -328,14 +244,11 @@ export default function CourseInfo({
                   <ProfessorInfoCard
                     key={instructorName}
                     professorName={instructorName}
-                    professorMetrics={
-                      professorMetricsMap[slugifyProfessor(instructorName)] ?? [
-                        { label: 'Overall Rating', value: '—' },
-                        { label: 'Course GPA', value: '—' },
-                        { label: 'Level of Difficulty', value: '—' },
-                        { label: 'Workload', value: '—', unit: 'hrs/week' },
-                      ]
+                    professorGpa={gpaMap?.[instructorName] ?? null}
+                    professorRatings={
+                      course.professorRatings?.[slugify(instructorName)] ?? null
                     }
+                    isRatingsLoaded={isProfessorRatingsLoaded}
                     course={course}
                     displaySectionInfo={selectedTermKey === term}
                   />

--- a/src/components/MetricsCard/index.tsx
+++ b/src/components/MetricsCard/index.tsx
@@ -4,7 +4,7 @@ import './stylesheet.scss';
 
 export type Metric = {
   label: string;
-  value: string;
+  value?: string | null;
   unit?: string;
 };
 
@@ -18,17 +18,26 @@ export default function MetricsCard({
   return (
     <div className="metrics-card-container">
       <ul className="metrics-list">
-        {metrics.map((metric, index) => (
-          <li key={index} className="metric-item">
-            <div className="metric-value-unit-container">
-              <span className="metric-value">{metric.value}</span>
-              {metric.unit && (
-                <span className="metric-unit"> {metric.unit}</span>
-              )}
-            </div>
-            <div className="metric-label">{metric.label}</div>
-          </li>
-        ))}
+        {metrics.map((metric, index) => {
+          const displayValue = metric.value ?? 'N/A';
+          const showUnit =
+            metric.value != null &&
+            !metric.value.toLowerCase().includes('loading') &&
+            metric.value !== 'N/A' &&
+            metric.unit;
+
+          return (
+            <li key={index} className="metric-item">
+              <div className="metric-value-unit-container">
+                <span className="metric-value">{displayValue}</span>
+                {showUnit && (
+                  <span className="metric-unit"> {metric.unit}</span>
+                )}
+              </div>
+              <div className="metric-label">{metric.label}</div>
+            </li>
+          );
+        })}
       </ul>
     </div>
   );

--- a/src/components/MetricsCard/stylesheet.scss
+++ b/src/components/MetricsCard/stylesheet.scss
@@ -35,6 +35,7 @@
 
         .metric-value {
           font-size: 1.25rem;
+          font-weight: bold;
         }
 
         .metric-unit {

--- a/src/components/ProfessorInfoCard/index.tsx
+++ b/src/components/ProfessorInfoCard/index.tsx
@@ -20,7 +20,13 @@ import './stylesheet.scss';
 
 export type ProfessorInfoCardProps = {
   professorName: string;
-  professorMetrics: Metric[];
+  professorGpa: number | null;
+  professorRatings: {
+    averageRating: number;
+    averageDifficulty: number;
+    averageWorkload: number;
+  } | null;
+  isRatingsLoaded: boolean;
   course: Course;
   displaySectionInfo: boolean;
 };
@@ -115,7 +121,9 @@ function SectionRow({
 
 export default function ProfessorInfoCard({
   professorName,
-  professorMetrics,
+  professorGpa,
+  professorRatings,
+  isRatingsLoaded,
   course,
   displaySectionInfo,
 }: ProfessorInfoCardProps): React.ReactElement {
@@ -127,6 +135,40 @@ export default function ProfessorInfoCard({
   });
   const [{ pinnedCrns, desiredCourses, colorMap, palette }, { patchSchedule }] =
     useContext(ScheduleContext);
+
+  const professorMetrics: Metric[] = useMemo(() => {
+    return [
+      {
+        label: 'Overall Rating',
+        value: !isRatingsLoaded
+          ? 'Loading...'
+          : professorRatings
+          ? `${professorRatings.averageRating.toFixed(2)}/5`
+          : null,
+      },
+      {
+        label: 'Course GPA',
+        value: professorGpa === null ? 'Loading...' : professorGpa.toFixed(2),
+      },
+      {
+        label: 'Level of Difficulty',
+        value: !isRatingsLoaded
+          ? 'Loading...'
+          : professorRatings
+          ? `${professorRatings.averageDifficulty.toFixed(1)}/5`
+          : null,
+      },
+      {
+        label: 'Workload',
+        value: !isRatingsLoaded
+          ? 'Loading...'
+          : professorRatings
+          ? professorRatings.averageWorkload.toFixed(1)
+          : null,
+        unit: 'hrs/week',
+      },
+    ];
+  }, [isRatingsLoaded, professorRatings, professorGpa]);
 
   const handleAddSection = (section: Section): void => {
     const updates: Partial<Schedule> = {

--- a/src/data/beans/Course.ts
+++ b/src/data/beans/Course.ts
@@ -31,10 +31,10 @@ const GPA_CACHE_LOCAL_STORAGE_KEY = 'course-gpa-cache-4';
 const GPA_CACHE_EXPIRATION_DURATION_DAYS = 7;
 
 const RATINGS_CACHE_LOCAL_STORAGE_KEY = 'course-ratings-cache-1';
-const RATINGS_CACHE_EXPIRATION_DURATION_DAYS = 7;
+const RATINGS_CACHE_EXPIRATION_DURATION_MINUTES = 15;
 
 const PROFESSOR_RATINGS_CACHE_LOCAL_STORAGE_KEY = 'professor-ratings-cache-1';
-const PROFESSOR_RATINGS_CACHE_EXPIRATION_DURATION_DAYS = 7;
+const PROFESSOR_RATINGS_CACHE_EXPIRATION_DURATION_MINUTES = 15;
 
 interface SectionGroupMeeting {
   days: string[];
@@ -402,7 +402,6 @@ export default class Course {
         const cacheItem = cache[this.id];
         if (cacheItem != null) {
           const now = new Date().toISOString();
-          // Use lexicographic comparison on date strings
           if (now < cacheItem.exp) {
             console.log('using cached ratings for', this.id, cacheItem);
             this.ratings = cacheItem.d;
@@ -419,9 +418,12 @@ export default class Course {
     if (ratingsResponse === null) {
       return null;
     }
+    console.log('fetched ratings for', this.id, ratingsResponse);
 
     const exp = new Date();
-    exp.setDate(exp.getDate() + RATINGS_CACHE_EXPIRATION_DURATION_DAYS);
+    exp.setMinutes(
+      exp.getMinutes() + RATINGS_CACHE_EXPIRATION_DURATION_MINUTES
+    );
     try {
       let cache: ratingsCache = {};
       const rawCache = window.localStorage.getItem(
@@ -460,14 +462,12 @@ export default class Course {
 
     let responseData: RatingStatsResponse;
     try {
-      // Create the payload
       const payload = {
         courses: normalizedCourses.length > 0 ? normalizedCourses : undefined,
         professors:
           normalizedProfessors.length > 0 ? normalizedProfessors : undefined,
       };
 
-      // Send as application/x-www-form-urlencoded with data nested inside
       responseData = (
         await axios.post<RatingStatsResponse>(
           url,
@@ -593,7 +593,6 @@ export default class Course {
       // Ignore
     }
 
-    // Fetch professor ratings normally
     if (this.professorRatings === undefined) {
       const allProfessors = Array.from(
         new Set(Object.values(this.termInfo).flat())
@@ -606,8 +605,8 @@ export default class Course {
       }
 
       const exp = new Date();
-      exp.setDate(
-        exp.getDate() + PROFESSOR_RATINGS_CACHE_EXPIRATION_DURATION_DAYS
+      exp.setMinutes(
+        exp.getMinutes() + PROFESSOR_RATINGS_CACHE_EXPIRATION_DURATION_MINUTES
       );
       try {
         let cache: ProfessorRatingsCache = {};

--- a/src/data/beans/Course.ts
+++ b/src/data/beans/Course.ts
@@ -403,7 +403,6 @@ export default class Course {
         if (cacheItem != null) {
           const now = new Date().toISOString();
           if (now < cacheItem.exp) {
-            console.log('using cached ratings for', this.id, cacheItem);
             this.ratings = cacheItem.d;
             return cacheItem.d;
           }
@@ -418,7 +417,6 @@ export default class Course {
     if (ratingsResponse === null) {
       return null;
     }
-    console.log('fetched ratings for', this.id, ratingsResponse);
 
     const exp = new Date();
     exp.setMinutes(
@@ -482,7 +480,6 @@ export default class Course {
     } catch (err) {
       // Ignore network errors
       if (!isAxiosNetworkError(err)) {
-        console.log(err);
         softError(
           new ErrorWithFields({
             message: 'error fetching ratings from ratings API',
@@ -582,9 +579,8 @@ export default class Course {
             this.professorRatings = {};
           }
           cacheItems.forEach(({ name, item }) => {
-            console.log('cached item', name, item);
-            this.professorRatings![name] = item?.d ?? null;
-            result[name] = item?.d ?? null;
+            this.professorRatings![slugifyProfessor(name)] = item?.d ?? null;
+            result[slugifyProfessor(name)] = item?.d ?? null;
           });
           return result;
         }
@@ -639,7 +635,7 @@ export default class Course {
     professorsInTerm.forEach((professor) => {
       const slugifiedName = slugifyProfessor(professor);
       if (slugifiedName in this.professorRatings!) {
-        result[professor] = this.professorRatings![slugifiedName] ?? null;
+        result[slugifiedName] = this.professorRatings![slugifiedName] ?? null;
       }
     });
 

--- a/src/data/beans/Course.ts
+++ b/src/data/beans/Course.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { decode } from 'html-entities';
+import { z } from 'zod';
 
 import { Oscar, Section } from '.';
 import {
@@ -29,6 +30,12 @@ const COURSE_CRITIQUE_API_URL = `${CLOUD_FUNCTION_BASE_URL}/getCourseDataFromCou
 const GPA_CACHE_LOCAL_STORAGE_KEY = 'course-gpa-cache-4';
 const GPA_CACHE_EXPIRATION_DURATION_DAYS = 7;
 
+const RATINGS_CACHE_LOCAL_STORAGE_KEY = 'course-ratings-cache-1';
+const RATINGS_CACHE_EXPIRATION_DURATION_DAYS = 7;
+
+const PROFESSOR_RATINGS_CACHE_LOCAL_STORAGE_KEY = 'professor-ratings-cache-1';
+const PROFESSOR_RATINGS_CACHE_EXPIRATION_DURATION_DAYS = 7;
+
 interface SectionGroupMeeting {
   days: string[];
   period: Period | undefined;
@@ -42,6 +49,42 @@ interface SectionGroup {
   meetings: SectionGroupMeeting[];
   sections: Section[];
 }
+
+const NormalizedStatSchema = z.object({
+  averageRating: z.number().nonnegative(),
+  averageDifficulty: z.number().nonnegative(),
+  averageWorkload: z.number().nonnegative(),
+  reviewCount: z.number().int().nonnegative(),
+});
+
+export interface NormalizedStat {
+  averageRating: number;
+  averageDifficulty: number;
+  averageWorkload: number;
+  reviewCount: number;
+}
+
+const RatingStatsResponseSchema = z.object({
+  courses: z.record(z.string(), NormalizedStatSchema.nullable()),
+  professors: z.record(z.string(), NormalizedStatSchema.nullable()),
+});
+
+export type RatingStatsResponse = z.infer<typeof RatingStatsResponseSchema>;
+
+export const slugifyCourse = (courseId: string): string => {
+  const [subject, number] = courseId.split(' ');
+  if (!subject || !number) return courseId;
+  const cleanNumber = number.replace(/\D/g, '');
+  return `${subject} ${cleanNumber}`;
+};
+
+export const slugifyProfessor = (name: string): string => {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-');
+};
 
 export default class Course {
   id: string;
@@ -75,6 +118,10 @@ export default class Course {
   termInfo: Record<string, string[]>;
 
   plannedCount: number | undefined;
+
+  ratings: NormalizedStat | null | undefined;
+
+  professorRatings: Record<string, NormalizedStat | null> | undefined;
 
   constructor(oscar: Oscar, courseId: string, data: CrawlerCourse) {
     this.term = oscar.term;
@@ -124,6 +171,9 @@ export default class Course {
     };
     this.prereqs = prereqs;
     this.coreqs = coreqs;
+
+    this.ratings = undefined;
+    this.professorRatings = undefined;
 
     const onlyLectures = this.sections.filter(
       (section) => isLecture(section) && !isLab(section)
@@ -331,6 +381,270 @@ export default class Course {
     }
 
     return this.decodeCourseCritiqueResponse(responseData);
+  }
+
+  async fetchRatings(): Promise<NormalizedStat | null> {
+    type ratingsCache = Record<string, ratingsCacheItem>;
+    interface ratingsCacheItem {
+      d: NormalizedStat | null;
+      exp: string;
+    }
+
+    // Try to look in the cache for a cached ratings item
+    try {
+      const rawCache = window.localStorage.getItem(
+        RATINGS_CACHE_LOCAL_STORAGE_KEY
+      );
+      if (rawCache != null) {
+        const cache: ratingsCache = JSON.parse(
+          rawCache
+        ) as unknown as ratingsCache;
+        const cacheItem = cache[this.id];
+        if (cacheItem != null) {
+          const now = new Date().toISOString();
+          // Use lexicographic comparison on date strings
+          if (now < cacheItem.exp) {
+            console.log('using cached ratings for', this.id, cacheItem);
+            this.ratings = cacheItem.d;
+            return cacheItem.d;
+          }
+        }
+      }
+    } catch (err) {
+      // Ignore
+    }
+
+    // Fetch the ratings normally
+    const ratingsResponse = await this.fetchRatingsInner([this.id], []);
+    if (ratingsResponse === null) {
+      return null;
+    }
+
+    const exp = new Date();
+    exp.setDate(exp.getDate() + RATINGS_CACHE_EXPIRATION_DURATION_DAYS);
+    try {
+      let cache: ratingsCache = {};
+      const rawCache = window.localStorage.getItem(
+        RATINGS_CACHE_LOCAL_STORAGE_KEY
+      );
+      if (rawCache != null) {
+        cache = JSON.parse(rawCache) as unknown as ratingsCache;
+      }
+      cache[this.id] = {
+        d: ratingsResponse.courses[this.id] ?? null,
+        exp: exp.toISOString(),
+      };
+      const rawUpdatedCache = JSON.stringify(cache);
+      window.localStorage.setItem(
+        RATINGS_CACHE_LOCAL_STORAGE_KEY,
+        rawUpdatedCache
+      );
+    } catch (err) {
+      // Ignore
+    }
+    const courseRating = ratingsResponse.courses[this.id] ?? null;
+    this.ratings = courseRating;
+
+    return courseRating;
+  }
+
+  private async fetchRatingsInner(
+    courses: string[],
+    professors: string[]
+  ): Promise<RatingStatsResponse | null> {
+    const normalizedCourses = courses.map((c) => slugifyCourse(c));
+    const normalizedProfessors = professors.map((p) => slugifyProfessor(p));
+
+    // TODO: update URL when deployed
+    const url = `http://localhost:5001/gt-scheduler-web-dev/us-east1/getRatingStats`;
+
+    let responseData: RatingStatsResponse;
+    try {
+      // Create the payload
+      const payload = {
+        courses: normalizedCourses.length > 0 ? normalizedCourses : undefined,
+        professors:
+          normalizedProfessors.length > 0 ? normalizedProfessors : undefined,
+      };
+
+      // Send as application/x-www-form-urlencoded with data nested inside
+      responseData = (
+        await axios.post<RatingStatsResponse>(
+          url,
+          `data=${encodeURIComponent(JSON.stringify(payload))}`,
+          {
+            headers: {
+              'Content-Type': 'application/x-www-form-urlencoded',
+            },
+          }
+        )
+      ).data;
+    } catch (err) {
+      // Ignore network errors
+      if (!isAxiosNetworkError(err)) {
+        console.log(err);
+        softError(
+          new ErrorWithFields({
+            message: 'error fetching ratings from ratings API',
+            source: err,
+            fields: {
+              courses: normalizedCourses,
+              professors: normalizedProfessors,
+              url,
+            },
+          })
+        );
+      }
+
+      return null;
+    }
+
+    // Validate the response data
+    try {
+      const validatedResponse = RatingStatsResponseSchema.parse(responseData);
+
+      const validateStat = (stat: NormalizedStat | null): boolean => {
+        if (stat === null) return true;
+
+        return (
+          stat.averageRating >= 1 &&
+          stat.averageRating <= 5 &&
+          stat.averageDifficulty >= 1 &&
+          stat.averageDifficulty <= 5 &&
+          stat.averageWorkload >= 0 &&
+          stat.reviewCount >= 0
+        );
+      };
+
+      for (const stat of Object.values(validatedResponse.courses)) {
+        if (!validateStat(stat)) {
+          throw new Error('Invalid rating values in course stats');
+        }
+      }
+
+      for (const stat of Object.values(validatedResponse.professors)) {
+        if (!validateStat(stat)) {
+          throw new Error('Invalid rating values in professor stats');
+        }
+      }
+
+      return validatedResponse;
+    } catch (err) {
+      softError(
+        new ErrorWithFields({
+          message: 'error validating ratings API response',
+          source: err,
+          fields: {
+            courses: normalizedCourses,
+            professors: normalizedProfessors,
+          },
+        })
+      );
+      return null;
+    }
+  }
+
+  async fetchProfessorRatings(
+    term: string
+  ): Promise<Record<string, NormalizedStat | null>> {
+    type ProfessorRatingsCache = Record<string, ProfessorRatingsCacheItem>;
+    interface ProfessorRatingsCacheItem {
+      d: NormalizedStat | null;
+      exp: string;
+    }
+
+    // Get professors who taught in this term
+    const professorsInTerm = this.termInfo[term] ?? [];
+
+    if (professorsInTerm.length === 0) {
+      return {};
+    }
+
+    try {
+      const rawCache = window.localStorage.getItem(
+        PROFESSOR_RATINGS_CACHE_LOCAL_STORAGE_KEY
+      );
+      if (rawCache != null) {
+        const cache: ProfessorRatingsCache = JSON.parse(
+          rawCache
+        ) as unknown as ProfessorRatingsCache;
+        const cacheItems = professorsInTerm.map((professor) => ({
+          name: professor,
+          item: cache[slugifyProfessor(professor)],
+        }));
+        const now = new Date().toISOString();
+        const allCached = cacheItems.every(
+          ({ item }) => item != null && now < item.exp
+        );
+        if (allCached) {
+          const result: Record<string, NormalizedStat | null> = {};
+          if (!this.professorRatings) {
+            this.professorRatings = {};
+          }
+          cacheItems.forEach(({ name, item }) => {
+            console.log('cached item', name, item);
+            this.professorRatings![name] = item?.d ?? null;
+            result[name] = item?.d ?? null;
+          });
+          return result;
+        }
+      }
+    } catch (err) {
+      // Ignore
+    }
+
+    // Fetch professor ratings normally
+    if (this.professorRatings === undefined) {
+      const allProfessors = Array.from(
+        new Set(Object.values(this.termInfo).flat())
+      );
+
+      const ratingsResponse = await this.fetchRatingsInner([], allProfessors);
+      if (ratingsResponse === null) {
+        this.professorRatings = {};
+        return {};
+      }
+
+      const exp = new Date();
+      exp.setDate(
+        exp.getDate() + PROFESSOR_RATINGS_CACHE_EXPIRATION_DURATION_DAYS
+      );
+      try {
+        let cache: ProfessorRatingsCache = {};
+        const rawCache = window.localStorage.getItem(
+          PROFESSOR_RATINGS_CACHE_LOCAL_STORAGE_KEY
+        );
+        if (rawCache != null) {
+          cache = JSON.parse(rawCache) as unknown as ProfessorRatingsCache;
+        }
+        allProfessors.forEach((professor) => {
+          const slugifiedName = slugifyProfessor(professor);
+          cache[slugifiedName] = {
+            d: ratingsResponse.professors[slugifiedName] ?? null,
+            exp: exp.toISOString(),
+          };
+        });
+        const rawUpdatedCache = JSON.stringify(cache);
+        window.localStorage.setItem(
+          PROFESSOR_RATINGS_CACHE_LOCAL_STORAGE_KEY,
+          rawUpdatedCache
+        );
+      } catch (err) {
+        // Ignore
+      }
+      this.professorRatings = ratingsResponse.professors;
+    }
+
+    const result: Record<string, NormalizedStat | null> = {};
+
+    professorsInTerm.forEach((professor) => {
+      const slugifiedName = slugifyProfessor(professor);
+      if (slugifiedName in this.professorRatings!) {
+        result[professor] = this.professorRatings![slugifiedName] ?? null;
+      }
+    });
+
+    return result;
   }
 
   private decodeCourseCritiqueResponse(

--- a/src/data/beans/Course.ts
+++ b/src/data/beans/Course.ts
@@ -579,8 +579,11 @@ export default class Course {
             this.professorRatings = {};
           }
           cacheItems.forEach(({ name, item }) => {
-            this.professorRatings![slugifyProfessor(name)] = item?.d ?? null;
-            result[slugifyProfessor(name)] = item?.d ?? null;
+            const slugifiedName = slugifyProfessor(name);
+            if (this.professorRatings) {
+              this.professorRatings[slugifiedName] = item?.d ?? null;
+            }
+            result[slugifiedName] = item?.d ?? null;
           });
           return result;
         }
@@ -634,8 +637,8 @@ export default class Course {
 
     professorsInTerm.forEach((professor) => {
       const slugifiedName = slugifyProfessor(professor);
-      if (slugifiedName in this.professorRatings!) {
-        result[slugifiedName] = this.professorRatings![slugifiedName] ?? null;
+      if (this.professorRatings && slugifiedName in this.professorRatings) {
+        result[slugifiedName] = this.professorRatings[slugifiedName] ?? null;
       }
     });
 

--- a/src/data/beans/Course.ts
+++ b/src/data/beans/Course.ts
@@ -1,6 +1,5 @@
 import axios from 'axios';
 import { decode } from 'html-entities';
-import { z } from 'zod';
 
 import { Oscar, Section } from '.';
 import {
@@ -15,6 +14,11 @@ import {
   isLab,
   isLecture,
   isAxiosNetworkError,
+  NormalizedStat,
+  RatingStatsResponse,
+  slugify,
+  normalizeCourseName,
+  validateRatingStatsResponse,
 } from '../../utils/misc';
 import { ErrorWithFields, softError } from '../../log';
 import { CLOUD_FUNCTION_BASE_URL } from '../../constants';
@@ -30,11 +34,16 @@ const COURSE_CRITIQUE_API_URL = `${CLOUD_FUNCTION_BASE_URL}/getCourseDataFromCou
 const GPA_CACHE_LOCAL_STORAGE_KEY = 'course-gpa-cache-4';
 const GPA_CACHE_EXPIRATION_DURATION_DAYS = 7;
 
+// Cache for course-level rating statistics
 const RATINGS_CACHE_LOCAL_STORAGE_KEY = 'course-ratings-cache-1';
 const RATINGS_CACHE_EXPIRATION_DURATION_MINUTES = 15;
 
+// Cache for professor-level rating statistics
 const PROFESSOR_RATINGS_CACHE_LOCAL_STORAGE_KEY = 'professor-ratings-cache-1';
 const PROFESSOR_RATINGS_CACHE_EXPIRATION_DURATION_MINUTES = 15;
+
+// TODO: update URL when deployed
+const DEV_GET_RATING_URL = `http://localhost:5001/gt-scheduler-web-dev/us-east1/getRatingStats`;
 
 interface SectionGroupMeeting {
   days: string[];
@@ -49,42 +58,6 @@ interface SectionGroup {
   meetings: SectionGroupMeeting[];
   sections: Section[];
 }
-
-const NormalizedStatSchema = z.object({
-  averageRating: z.number().nonnegative(),
-  averageDifficulty: z.number().nonnegative(),
-  averageWorkload: z.number().nonnegative(),
-  reviewCount: z.number().int().nonnegative(),
-});
-
-export interface NormalizedStat {
-  averageRating: number;
-  averageDifficulty: number;
-  averageWorkload: number;
-  reviewCount: number;
-}
-
-const RatingStatsResponseSchema = z.object({
-  courses: z.record(z.string(), NormalizedStatSchema.nullable()),
-  professors: z.record(z.string(), NormalizedStatSchema.nullable()),
-});
-
-export type RatingStatsResponse = z.infer<typeof RatingStatsResponseSchema>;
-
-export const slugifyCourse = (courseId: string): string => {
-  const [subject, number] = courseId.split(' ');
-  if (!subject || !number) return courseId;
-  const cleanNumber = number.replace(/\D/g, '');
-  return `${subject} ${cleanNumber}`;
-};
-
-export const slugifyProfessor = (name: string): string => {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9\s-]/g, '')
-    .trim()
-    .replace(/\s+/g, '-');
-};
 
 export default class Course {
   id: string;
@@ -452,11 +425,8 @@ export default class Course {
     courses: string[],
     professors: string[]
   ): Promise<RatingStatsResponse | null> {
-    const normalizedCourses = courses.map((c) => slugifyCourse(c));
-    const normalizedProfessors = professors.map((p) => slugifyProfessor(p));
-
-    // TODO: update URL when deployed
-    const url = `http://localhost:5001/gt-scheduler-web-dev/us-east1/getRatingStats`;
+    const normalizedCourses = courses.map((c) => normalizeCourseName(c));
+    const normalizedProfessors = professors.map((p) => slugify(p));
 
     let responseData: RatingStatsResponse;
     try {
@@ -468,7 +438,7 @@ export default class Course {
 
       responseData = (
         await axios.post<RatingStatsResponse>(
-          url,
+          DEV_GET_RATING_URL,
           `data=${encodeURIComponent(JSON.stringify(payload))}`,
           {
             headers: {
@@ -487,7 +457,7 @@ export default class Course {
             fields: {
               courses: normalizedCourses,
               professors: normalizedProfessors,
-              url,
+              DEV_GET_RATING_URL,
             },
           })
         );
@@ -496,41 +466,14 @@ export default class Course {
       return null;
     }
 
-    // Validate the response data
-    try {
-      const validatedResponse = RatingStatsResponseSchema.parse(responseData);
+    // Validate the response data using reusable function
+    const validatedResponse = validateRatingStatsResponse(responseData);
 
-      const validateStat = (stat: NormalizedStat | null): boolean => {
-        if (stat === null) return true;
-
-        return (
-          stat.averageRating >= 1 &&
-          stat.averageRating <= 5 &&
-          stat.averageDifficulty >= 1 &&
-          stat.averageDifficulty <= 5 &&
-          stat.averageWorkload >= 0 &&
-          stat.reviewCount >= 0
-        );
-      };
-
-      for (const stat of Object.values(validatedResponse.courses)) {
-        if (!validateStat(stat)) {
-          throw new Error('Invalid rating values in course stats');
-        }
-      }
-
-      for (const stat of Object.values(validatedResponse.professors)) {
-        if (!validateStat(stat)) {
-          throw new Error('Invalid rating values in professor stats');
-        }
-      }
-
-      return validatedResponse;
-    } catch (err) {
+    if (validatedResponse === null) {
       softError(
         new ErrorWithFields({
           message: 'error validating ratings API response',
-          source: err,
+          source: new Error('Validation failed'),
           fields: {
             courses: normalizedCourses,
             professors: normalizedProfessors,
@@ -539,6 +482,8 @@ export default class Course {
       );
       return null;
     }
+
+    return validatedResponse;
   }
 
   async fetchProfessorRatings(
@@ -552,94 +497,89 @@ export default class Course {
 
     // Get professors who taught in this term
     const professorsInTerm = this.termInfo[term] ?? [];
-
     if (professorsInTerm.length === 0) {
       return {};
     }
+    if (!this.professorRatings) {
+      this.professorRatings = {};
+    }
 
+    const { professorRatings } = this;
+    const now = new Date().toISOString();
+    const professorsToFetch: string[] = [];
+    const cachedResults: Record<string, NormalizedStat | null> = {};
+
+    let cache: ProfessorRatingsCache = {};
     try {
       const rawCache = window.localStorage.getItem(
         PROFESSOR_RATINGS_CACHE_LOCAL_STORAGE_KEY
       );
       if (rawCache != null) {
-        const cache: ProfessorRatingsCache = JSON.parse(
-          rawCache
-        ) as unknown as ProfessorRatingsCache;
-        const cacheItems = professorsInTerm.map((professor) => ({
-          name: professor,
-          item: cache[slugifyProfessor(professor)],
-        }));
-        const now = new Date().toISOString();
-        const allCached = cacheItems.every(
-          ({ item }) => item != null && now < item.exp
-        );
-        if (allCached) {
-          const result: Record<string, NormalizedStat | null> = {};
-          if (!this.professorRatings) {
-            this.professorRatings = {};
-          }
-          cacheItems.forEach(({ name, item }) => {
-            const slugifiedName = slugifyProfessor(name);
-            if (this.professorRatings) {
-              this.professorRatings[slugifiedName] = item?.d ?? null;
-            }
-            result[slugifiedName] = item?.d ?? null;
-          });
-          return result;
-        }
+        cache = JSON.parse(rawCache) as unknown as ProfessorRatingsCache;
       }
     } catch (err) {
-      // Ignore
+      // Ignore cache read errors
     }
 
-    if (this.professorRatings === undefined) {
-      const allProfessors = Array.from(
-        new Set(Object.values(this.termInfo).flat())
-      );
+    professorsInTerm.forEach((professor) => {
+      const slugifiedName = slugify(professor);
 
-      const ratingsResponse = await this.fetchRatingsInner([], allProfessors);
-      if (ratingsResponse === null) {
-        this.professorRatings = {};
-        return {};
+      if (slugifiedName in professorRatings) {
+        cachedResults[slugifiedName] = professorRatings[slugifiedName] ?? null;
+        return;
       }
 
-      const exp = new Date();
-      exp.setMinutes(
-        exp.getMinutes() + PROFESSOR_RATINGS_CACHE_EXPIRATION_DURATION_MINUTES
+      const cacheItem = cache[slugifiedName];
+      if (cacheItem != null && now < cacheItem.exp) {
+        cachedResults[slugifiedName] = cacheItem.d;
+        professorRatings[slugifiedName] = cacheItem.d;
+      } else {
+        professorsToFetch.push(professor);
+      }
+    });
+
+    // Fetch only missing/expired professors
+    if (professorsToFetch.length > 0) {
+      const ratingsResponse = await this.fetchRatingsInner(
+        [],
+        professorsToFetch
       );
-      try {
-        let cache: ProfessorRatingsCache = {};
-        const rawCache = window.localStorage.getItem(
-          PROFESSOR_RATINGS_CACHE_LOCAL_STORAGE_KEY
+
+      if (ratingsResponse !== null) {
+        const exp = new Date();
+        exp.setMinutes(
+          exp.getMinutes() + PROFESSOR_RATINGS_CACHE_EXPIRATION_DURATION_MINUTES
         );
-        if (rawCache != null) {
-          cache = JSON.parse(rawCache) as unknown as ProfessorRatingsCache;
+
+        // Merge results
+        try {
+          professorsToFetch.forEach((professor) => {
+            const slugifiedName = slugify(professor);
+            const rating = ratingsResponse.professors[slugifiedName] ?? null;
+
+            professorRatings[slugifiedName] = rating;
+            cache[slugifiedName] = {
+              d: rating,
+              exp: exp.toISOString(),
+            };
+            cachedResults[slugifiedName] = rating;
+          });
+
+          const rawUpdatedCache = JSON.stringify(cache);
+          window.localStorage.setItem(
+            PROFESSOR_RATINGS_CACHE_LOCAL_STORAGE_KEY,
+            rawUpdatedCache
+          );
+        } catch (err) {
+          // Ignore cache write errors
         }
-        allProfessors.forEach((professor) => {
-          const slugifiedName = slugifyProfessor(professor);
-          cache[slugifiedName] = {
-            d: ratingsResponse.professors[slugifiedName] ?? null,
-            exp: exp.toISOString(),
-          };
-        });
-        const rawUpdatedCache = JSON.stringify(cache);
-        window.localStorage.setItem(
-          PROFESSOR_RATINGS_CACHE_LOCAL_STORAGE_KEY,
-          rawUpdatedCache
-        );
-      } catch (err) {
-        // Ignore
       }
-      this.professorRatings = ratingsResponse.professors;
     }
 
     const result: Record<string, NormalizedStat | null> = {};
-
     professorsInTerm.forEach((professor) => {
-      const slugifiedName = slugifyProfessor(professor);
-      if (this.professorRatings && slugifiedName in this.professorRatings) {
-        result[slugifiedName] = this.professorRatings[slugifiedName] ?? null;
-      }
+      const slugifiedName = slugify(professor);
+      result[slugifiedName] = cachedResults[slugifiedName] ?? null;
     });
 
     return result;

--- a/src/utils/misc.tsx
+++ b/src/utils/misc.tsx
@@ -5,6 +5,7 @@ import { getSanitizedOptions } from 'exponential-backoff/dist/options';
 import domtoimage from 'dom-to-image';
 import { saveAs } from 'file-saver';
 import { Immutable } from 'immer';
+import { z } from 'zod';
 
 import { Oscar, Section } from '../data/beans';
 import {
@@ -571,12 +572,16 @@ export function abbreviateLocation(location: string): string {
 
 // Normalize Course Names
 // e.g. "cs1331" -> "CS 1331", "MATH 1551" -> "MATH 1551"
-export function normalizeCourseName(courseName: string): string {
+export function normalizeCourseName(
+  courseName: string,
+  trimSection = false
+): string {
   let normalizedName = courseName;
   const results = /^([A-Z]+)(\d.*)$/i.exec(courseName);
   if (results != null) {
     const [, subject, number] = results as unknown as [string, string, string];
-    normalizedName = `${subject} ${number}`;
+    const cleanNumber = trimSection ? number.replace(/\D/g, '') : number;
+    normalizedName = `${subject} ${cleanNumber}`;
   }
   return normalizedName;
 }
@@ -598,4 +603,77 @@ export function normalizeSeatingData(raw: Seating): SeatData {
     inClass: toOccupiedInfo(inClassTotal, inClassOccupied),
     waitlist: toOccupiedInfo(waitlistTotal, waitlistOccupied),
   };
+}
+
+const NormalizedStatSchema = z.object({
+  averageRating: z.number().nonnegative(),
+  averageDifficulty: z.number().nonnegative(),
+  averageWorkload: z.number().nonnegative(),
+  reviewCount: z.number().int().nonnegative(),
+});
+
+export interface NormalizedStat {
+  averageRating: number;
+  averageDifficulty: number;
+  averageWorkload: number;
+  reviewCount: number;
+}
+
+const RatingStatsResponseSchema = z.object({
+  courses: z.record(z.string(), NormalizedStatSchema.nullable()),
+  professors: z.record(z.string(), NormalizedStatSchema.nullable()),
+});
+
+export type RatingStatsResponse = z.infer<typeof RatingStatsResponseSchema>;
+
+export const slugify = (name: string): string => {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-');
+};
+
+/**
+ * Validates rating statistics from the ratings API response
+ * @param response - The rating stats response to validate
+ * @returns The validated response or null if validation fails
+ */
+export function validateRatingStatsResponse(
+  response: unknown
+): RatingStatsResponse | null {
+  try {
+    const validatedResponse = RatingStatsResponseSchema.parse(response);
+
+    const validateStat = (stat: NormalizedStat | null): boolean => {
+      if (stat === null) return true;
+
+      return (
+        stat.averageRating >= 1 &&
+        stat.averageRating <= 5 &&
+        stat.averageDifficulty >= 1 &&
+        stat.averageDifficulty <= 5 &&
+        stat.averageWorkload >= 0 &&
+        stat.reviewCount >= 0
+      );
+    };
+
+    // Validate all course stats
+    for (const stat of Object.values(validatedResponse.courses)) {
+      if (!validateStat(stat)) {
+        throw new Error('Invalid rating values in course stats');
+      }
+    }
+
+    // Validate all professor stats
+    for (const stat of Object.values(validatedResponse.professors)) {
+      if (!validateStat(stat)) {
+        throw new Error('Invalid rating values in professor stats');
+      }
+    }
+
+    return validatedResponse;
+  } catch (err) {
+    return null;
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11393,6 +11393,11 @@ yocto-queue@^0.1.0:
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
+zod@^4.3.6:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.3.6.tgz#89c56e0aa7d2b05107d894412227087885ab112a"
+  integrity sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==
+
 zxcvbn@^4.4.2:
   version "4.4.2"
   resolved "https://registry.npmjs.org/zxcvbn/-/zxcvbn-4.4.2.tgz"


### PR DESCRIPTION
### Summary

Resolves #430 

### Checklist
- [x] Added a new ratings field in the Course bean.
- [x] Created a new fetchRatingsInner function within the Course bean.
- [x] Added fetchRatings function in the Course bean.
- [x] Added fetchProfessorRatings function in the Course bean.
- [x] Called these functions in the front-end (CourseInfo). 
- [x] Added 15 minute caching for the ratings.

### How to Test
in firebase-conf (comment out auth) & deploy dev. then run:
```
curl -X POST http://localhost:5001/gt-scheduler-web-dev/us-east1/submitRatings \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d 'data={"IDToken":"abc","ratings":[{"courseId":"CS 6210","professorId":"anand-padmanabha-iyer","term":202602,"rating":4,"difficulty":4,"workload":4}]}'
```
```
curl -X POST http://localhost:5001/gt-scheduler-web-dev/us-east1/submitRatings \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d 'data={"IDToken":"abc","ratings":[{"courseId":"CS 6210","professorId":"umakishore-ramachandran","term":202602,"rating":3,"difficulty":3,"workload":3}]}'
```
Verify ratings are displayed:
<img width="620" height="159" alt="Screenshot 2026-02-01 at 3 27 41 PM" src="https://github.com/user-attachments/assets/a3ed5271-4478-4f39-86f6-4aa9f5bcbae9" />
<img width="619" height="673" alt="Screenshot 2026-02-01 at 3 27 52 PM" src="https://github.com/user-attachments/assets/f12b9bdc-9e63-45f6-8393-609ae41701c7" />
Professors with no ratings:
<img width="619" height="419" alt="Screenshot 2026-02-01 at 3 28 05 PM" src="https://github.com/user-attachments/assets/20b2ab3a-e2fa-4afb-a1c5-ee0b405c1eee" />
Courses with no ratings:
<img width="617" height="446" alt="Screenshot 2026-02-01 at 3 28 40 PM" src="https://github.com/user-attachments/assets/f0969936-0a3a-4ec7-83dc-403e0f7e28d5" />

Verified that deleting and re-adding a course uses cached results with 15 minute expiration:
<img width="252" height="129" alt="Screenshot 2026-02-01 at 3 31 19 PM" src="https://github.com/user-attachments/assets/7b98501d-1f6b-43bb-8ee0-6d1fedabd8c7" />
<img width="249" height="116" alt="Screenshot 2026-02-01 at 3 31 34 PM" src="https://github.com/user-attachments/assets/4dfe2d0f-ed6c-48ec-94d3-9945914a5135" />

