### PR TITLE
feat: add ability to add classes by CRN

### DIFF
--- a/src/components/CourseAdd/index.tsx
+++ b/src/components/CourseAdd/index.tsx
@@ -18,6 +18,17 @@ import { Course as CourseBean, Section } from '../../data/beans';
 
 import './stylesheet.scss';
 
+/** GT CRNs are 5 digits */
+const CRN_LENGTH = 5;
+
+function normalizeCrnInput(value: string): string {
+  return value.replace(/\D/g, '').slice(0, CRN_LENGTH);
+}
+
+function normalizeCrnPaste(value: string): string {
+  return value.replace(/\s/g, '').replace(/\D/g, '').slice(0, CRN_LENGTH);
+}
+
 export type CourseAddProps = {
   className?: string;
 };
@@ -72,8 +83,10 @@ function doesFilterMatchSection(section: Section, filter: SortFilter): boolean {
 export default function CourseAdd({
   className,
 }: CourseAddProps): React.ReactElement {
-  const [{ oscar, desiredCourses, excludedCrns, colorMap }, { patchSchedule }] =
-    useContext(ScheduleContext);
+  const [
+    { oscar, desiredCourses, pinnedCrns, excludedCrns, colorMap },
+    { patchSchedule },
+  ] = useContext(ScheduleContext);
   const [keyword, setKeyword] = useState('');
   const [filter, setFilter] = useState<SortFilter>({
     deliveryMode: [],
@@ -81,6 +94,10 @@ export default function CourseAdd({
   });
   const [activeIndex, setActiveIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const [crnInput, setCrnInput] = useState('');
+  const [crnError, setCrnError] = useState<string | null>(null);
+  const crnInputRef = useRef<HTMLInputElement | null>(null);
 
   const handleChangeKeyword = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
@@ -191,6 +208,75 @@ export default function CourseAdd({
     [filter]
   );
 
+  const crnNormalized = useMemo(
+    () => normalizeCrnPaste(crnInput),
+    [crnInput]
+  );
+  const isCrnValid = crnNormalized.length === CRN_LENGTH;
+
+  const handleCrnChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const raw = e.target.value;
+      const next = raw.includes(' ') || raw.includes('\n')
+        ? normalizeCrnPaste(raw)
+        : normalizeCrnInput(raw);
+      setCrnInput(next);
+      if (crnError) setCrnError(null);
+    },
+    [crnError]
+  );
+
+  const handleAddByCrn = useCallback(() => {
+    if (!isCrnValid) return;
+    const crn = crnNormalized;
+
+    if (pinnedCrns.includes(crn)) {
+      setCrnError('This section is already in your schedule.');
+      return;
+    }
+
+    const section = oscar.findSection(crn);
+    if (section == null) {
+      setCrnError('CRN not found for this term.');
+      return;
+    }
+
+    const courseId = section.course.id;
+    patchSchedule({
+      desiredCourses: desiredCourses.includes(courseId)
+        ? desiredCourses
+        : [...desiredCourses, courseId],
+      pinnedCrns: [...pinnedCrns, crn],
+      excludedCrns: excludedCrns.filter((c) => c !== crn),
+      colorMap:
+        colorMap[courseId] != null
+          ? colorMap
+          : { ...colorMap, [courseId]: getRandomColor() },
+    });
+    setCrnInput('');
+    setCrnError(null);
+    crnInputRef.current?.focus();
+  }, [
+    isCrnValid,
+    crnNormalized,
+    pinnedCrns,
+    oscar,
+    desiredCourses,
+    excludedCrns,
+    colorMap,
+    patchSchedule,
+  ]);
+
+  const handleCrnKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        if (isCrnValid) handleAddByCrn();
+      }
+    },
+    [isCrnValid, handleAddByCrn]
+  );
+
   const activeCourse = courses[activeIndex];
 
   return (
@@ -232,6 +318,36 @@ export default function CourseAdd({
             onToggle={(tag): void => handleToggleFilter(property, tag)}
           />
         ))}
+        <div className="crn-row">
+          <label className="crn-label" htmlFor="crn-input">
+            CRN
+          </label>
+          <input
+            id="crn-input"
+            ref={crnInputRef}
+            type="text"
+            inputMode="numeric"
+            autoComplete="off"
+            className="crn-input"
+            placeholder={`${CRN_LENGTH} digits`}
+            value={crnInput}
+            onChange={handleCrnChange}
+            onKeyDown={handleCrnKeyDown}
+          />
+          <button
+            type="button"
+            className="crn-add"
+            disabled={!isCrnValid}
+            onClick={handleAddByCrn}
+          >
+            Add
+          </button>
+        </div>
+        {crnError != null && (
+          <div className="crn-error" role="alert">
+            {crnError}
+          </div>
+        )}
       </div>
       {courses.length > 0 ? (
         courses.map((course) => (

--- a/src/components/CourseAdd/stylesheet.scss
+++ b/src/components/CourseAdd/stylesheet.scss
@@ -55,6 +55,58 @@
         }
       }
     }
+
+    .crn-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px;
+      flex-wrap: wrap;
+
+      .crn-label {
+        font-weight: bold;
+        min-width: 2.5em;
+      }
+
+      .crn-input {
+        flex: 1;
+        min-width: 80px;
+        max-width: 120px;
+        padding: 6px 8px;
+        font-size: inherit;
+        border: 1px solid $color-neutral;
+        border-radius: 4px;
+
+        &::placeholder {
+          color: $color-neutral;
+        }
+      }
+
+      .crn-add {
+        padding: 6px 12px;
+        font-size: inherit;
+        font-weight: bold;
+        cursor: pointer;
+        border-radius: 4px;
+        border: 1px solid $color-neutral;
+        background-color: $color-border;
+
+        &:disabled {
+          opacity: 0.6;
+          cursor: not-allowed;
+        }
+
+        &:not(:disabled):hover {
+          opacity: 0.9;
+        }
+      }
+    }
+
+    .crn-error {
+      padding: 4px 8px;
+      font-size: 0.9em;
+      color: $color-neutral;
+    }
   }
 
   .Course {


### PR DESCRIPTION
This PR adds support for adding a class directly by CRN.

Users can enter a CRN to resolve the corresponding section and add it to their schedule without first selecting the course and section manually.

The implementation reuses existing section data and schedule mutation logic, and includes basic validation and error handling for invalid or duplicate CRNs.

No existing behavior is changed.
#417