### PR TITLE
fix: allow disabling Compare Schedules when unauthenticated

### DIFF
--- a/src/components/ComparisonPanel/index.tsx
+++ b/src/components/ComparisonPanel/index.tsx
@@ -58,11 +58,12 @@ export default function ComparisonPanel({
   }, [type]);
 
   const handleTogglePanel = useCallback(() => {
-    if (type === 'signedIn') {
-      handleCompareSchedules(!compare, undefined, undefined);
-    } else {
+    const enablingCompare = !compare;
+    if (type !== 'signedIn' && enablingCompare) {
       setLoginOpen(true);
+      return;
     }
+    handleCompareSchedules(!compare, undefined, undefined);
   }, [type, compare, handleCompareSchedules]);
 
   const [shareBackRemount, setShareBackRemount] = useState(0);


### PR DESCRIPTION
This PR fixes a bug where unauthenticated users could not disable the
"Compare Schedules" feature after it was enabled via an invite link.

Disabling Compare Schedules no longer requires authentication. Login is
only required when attempting to enable the feature.

This prevents users from getting stuck in compare mode without an account
and restores access to their own schedule.

#422