### PR TITLE
Add junior software engineers to mechanize banner

### DIFF
--- a/src/components/Banner/stylesheet.scss
+++ b/src/components/Banner/stylesheet.scss
@@ -10,6 +10,7 @@
   .bannerContent {
     flex: 1;
     text-align: center;
+    margin: 8px 0;
   }
 
   .bannerButton {

--- a/src/components/SponsorBanner/index.tsx
+++ b/src/components/SponsorBanner/index.tsx
@@ -9,7 +9,7 @@ const SPONSOR_LINK =
 function Content(): React.ReactElement {
   return (
     <span>
-      Mechanize is hiring. 250k base + equity.{' '}
+      Mechanize is hiring junior software engineers. 250k base + equity.{' '}
       <a
         className="bannerButton"
         href={SPONSOR_LINK}


### PR DESCRIPTION
Mechanize wants us to specify the position they are hiring for.

Test with `yarn start` or check out the [PR preview](https://gt-scheduler.github.io/website/pr-preview/pr-442/) for the updated banner. Note that you may have to clear your cookies for the banner to show up if you have previously exited it.