### PR TITLE
reconfigure banner to rotate slogans

### DIFF
--- a/src/components/SponsorBanner/index.tsx
+++ b/src/components/SponsorBanner/index.tsx
@@ -1,15 +1,22 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 
 import Banner from '../Banner';
 
-const BANNER_LOCAL_STORAGE_KEY = '2026-03-03-mechanize-survey-banner';
+const BANNER_LOCAL_STORAGE_KEY = '2026-04-14-mechanize-survey-banner';
 const SPONSOR_LINK =
   'https://jobs.ashbyhq.com/mechanize?utm_source=gt-scheduler';
 
-function Content(): React.ReactElement {
+const SLOGANS = [
+  'Better at coding than AI? Prove it. Mechanize: $300k + equity.',
+  'Mechanize is hiring junior software engineers. 300k base + equity.',
+  "We hire engineers to outsmart AI. It's harder than you think. $300k + equity.",
+  "Most engineers can't beat Claude on our take-home. Think you can? $300k + equity for junior SWEs at Mechanize.",
+];
+
+function Content({ text }: { text: string }): React.ReactElement {
   return (
     <span>
-      Mechanize is hiring junior software engineers. 300k base + equity.{' '}
+      {text}{' '}
       <a
         className="bannerButton"
         href={SPONSOR_LINK}
@@ -22,12 +29,23 @@ function Content(): React.ReactElement {
   );
 }
 
-export default function SponsorBanner(): React.ReactElement {
+export default function SponsorBanner(): React.ReactElement | null {
+  const [slogan, setSlogan] = useState(SLOGANS[0]);
+
+  useEffect(() => {
+    const randomIndex = Math.floor(Math.random() * SLOGANS.length);
+    setSlogan(SLOGANS[randomIndex]);
+  }, []);
+
+  if (!slogan) {
+    return null;
+  }
+
   return (
     <Banner
       localStorageKey={BANNER_LOCAL_STORAGE_KEY}
-      content={<Content />}
-      mobileContent={<Content />}
+      content={<Content text={slogan} />}
+      mobileContent={<Content text={slogan} />}
     />
   );
 }


### PR DESCRIPTION
### Summary
Rotate the sponsorship banner to go through the following slogans randomly:

1. Better at coding than AI? Prove it. Mechanize: $300k + equity. [Apply now!](https://jobs.ashbyhq.com/mechanize?utm_source=gt-scheduler)
2. Mechanize is hiring junior software engineers. 300k base + equity. [Apply now!](https://jobs.ashbyhq.com/mechanize?utm_source=gt-scheduler)
3. We hire engineers to outsmart AI. It's harder than you think. $300k + equity. [Apply now!](https://jobs.ashbyhq.com/mechanize?utm_source=gt-scheduler)
4. Most engineers can't beat Claude on our take-home. Think you can? $300k + equity for junior SWEs at Mechanize. [Apply now!](https://jobs.ashbyhq.com/mechanize?utm_source=gt-scheduler)

Rip the typo in the branch name.

### How to Test
Deploy Preview:

Keep refreshing the page to see the other slogans.